### PR TITLE
Fix env build - omit checkout exact commit

### DIFF
--- a/src/PHPCensor/Model/Build/RemoteGitBuild.php
+++ b/src/PHPCensor/Model/Build/RemoteGitBuild.php
@@ -141,7 +141,7 @@ class RemoteGitBuild extends Build
         $commit  = $this->getCommitId();
         $chdir   = 'cd "%s"';
 
-        if (!empty($commit) && $commit != 'Manual') {
+        if (empty($this->getEnvironment()) && !empty($commit) && $commit != 'Manual') {
             $cmd = $chdir . ' && git checkout %s --quiet';
             $success = $builder->executeCommand($cmd, $cloneTo, $commit);
         }


### PR DESCRIPTION
When building an environment, the attempt to check out the specified commit is erroneous, since the environment is a collection of certain branches.