### PR TITLE
Fix Migrations | Installation Failed

### DIFF
--- a/src/PHPCensor/Migrations/20171014173348_removed_project_id_from_build_meta.php
+++ b/src/PHPCensor/Migrations/20171014173348_removed_project_id_from_build_meta.php
@@ -8,6 +8,10 @@ class RemovedProjectIdFromBuildMeta extends AbstractMigration
     {
         $table = $this->table('build_meta');
 
+        if ($table->hasForeignKey('project_id')) {
+            $table->dropForeignKey('project_id');
+        }
+
         if ($table->hasColumn('project_id')) {
             $table
                 ->removeColumn('project_id')
@@ -21,7 +25,14 @@ class RemovedProjectIdFromBuildMeta extends AbstractMigration
 
         if (!$table->hasColumn('project_id')) {
             $table
-                ->addColumn('project_id', 'integer', ['default' => 0])
+                ->addColumn(
+                    'project_id',
+                    'integer', [
+                        'default' => 0,
+                        'after' => 'id'
+                    ]
+                )
+                ->addForeignKey('project_id', 'project', 'id', ['delete'=> 'CASCADE', 'update' => 'CASCADE'])
                 ->save();
         }
     }


### PR DESCRIPTION
Resolve Issue #127 

- Repair migrations at file `RemovedProjectIdFromBuildMeta`
- Remove foreign key before remove `project_id` field
- Add foreign key at down migration