### PR TITLE
PhpParallelLint Short tags Option expecting string

### DIFF
--- a/src/PHPCensor/Plugin/PhpParallelLint.php
+++ b/src/PHPCensor/Plugin/PhpParallelLint.php
@@ -67,7 +67,7 @@ class PhpParallelLint extends Plugin implements ZeroConfigPluginInterface
         }
 
         if (isset($options['shorttags'])) {
-            $this->shortTag = (strtolower($options['shorttags']) == 'true');
+            $this->shortTag = $options['shorttags'];
         }
 
         if (isset($options['extensions'])) {


### PR DESCRIPTION
This is actually a bool already, so it should just read it straight in.

Otherwise:
```
php_parallel_lint:
    shorttags: true
```

Won't get applied.

## Contribution type

Bugfix

## Description of change

The original version of this expected the option to be a string. This makes it more in keeping with the rest of the option parsing.