### PR TITLE
Technical Debt Plugin 'Allowed Errors' config ignored

### DIFF
--- a/src/PHPCensor/Plugin/TechnicalDebt.php
+++ b/src/PHPCensor/Plugin/TechnicalDebt.php
@@ -138,6 +138,10 @@ class TechnicalDebt extends Plugin implements ZeroConfigPluginInterface
             $this->allowedErrors = -1;
         }
 
+        if (array_key_exists('allowed_errors', $options) && $options['allowed_errors']) {
+            $this->allowedErrors = (int) $options['allowed_errors'];
+        }
+
         $this->setOptions($options);
     }
 
@@ -148,7 +152,7 @@ class TechnicalDebt extends Plugin implements ZeroConfigPluginInterface
      */
     protected function setOptions($options)
     {
-        foreach (['directory', 'ignore', 'allowed_errors'] as $key) {
+        foreach (['directory', 'ignore'] as $key) {
             if (array_key_exists($key, $options)) {
                 $this->{$key} = $options[$key];
             }


### PR DESCRIPTION
## Contribution type
Bug fix.

## Description of change
Sets the `allowed_errors` plugin property correctly, from the given config options.

At the moment, the `allowed_errors` config value is set in to a `$allowed_errors` class property, which is incorrect as the Technical Debt Plugin references the `$allowedErrors` class property to determine the success of the plugin's execution.

It's perhaps worth considering:
- Changing the config key from `allowed_errors` to `allowed_warnings`, like every other plugin.
- Consolidating the logic of `allowed_warnings` between all plugins. Should make them a bit more DRY.