### PR TITLE
PHPDocBlockChecker Plugin Detailed Error Logging

### DIFF
--- a/src/PHPCensor/Plugin/PhpDocblockChecker.php
+++ b/src/PHPCensor/Plugin/PhpDocblockChecker.php
@@ -149,7 +149,7 @@ class PhpDocblockChecker extends Plugin implements ZeroConfigPluginInterface
 
     /**
      * Report all of the errors we've encountered line-by-line.
-     * @param $output
+     * @param array $output
      */
     protected function reportErrors($output)
     {

--- a/src/PHPCensor/Plugin/PhpDocblockChecker.php
+++ b/src/PHPCensor/Plugin/PhpDocblockChecker.php
@@ -154,12 +154,43 @@ class PhpDocblockChecker extends Plugin implements ZeroConfigPluginInterface
     protected function reportErrors($output)
     {
         foreach ($output as $error) {
-            $message = 'Class ' . $error['class'] . ' is missing a docblock.';
-            $severity = BuildError::SEVERITY_LOW;
+            switch ($error['type']) {
+                case 'class':
+                    $message = 'Class ' . $error['class'] . ' is missing a docblock.';
+                    $severity = BuildError::SEVERITY_NORMAL;
+                    break;
 
-            if ($error['type'] == 'method') {
-                $message = $error['class'] . '::' . $error['method'] . ' is missing a docblock.';
-                $severity = BuildError::SEVERITY_NORMAL;
+                case 'method':
+                    $message = $error['class'] . '::' . $error['method'] . ' is missing a docblock.';
+                    $severity = BuildError::SEVERITY_NORMAL;
+                    break;
+
+                case 'param-missing':
+                    $message = $error['class'] . '::' . $error['method'] . ' @param ' . $error['param'] . ' missing.';
+                    $severity = BuildError::SEVERITY_LOW;
+                    break;
+
+                case 'param-mismatch':
+                    $message = $error['class'] . '::' . $error['method'] . ' @param ' . $error['param'] .
+                        '(' . $error['doc-type'] . ') does not match method signature (' . $error['param-type'] . ')';
+                    $severity = BuildError::SEVERITY_LOW;
+                    break;
+
+                case 'return-missing':
+                    $message = $error['class'] . '::' . $error['method'] . ' @return missing.';
+                    $severity = BuildError::SEVERITY_LOW;
+                    break;
+
+                case 'return-mismatch':
+                    $message = $error['class'] . '::' . $error['method'] . ' @return ' . $error['doc-type'] .
+                        ' does not match method signature (' . $error['return-type'] . ')';
+                    $severity = BuildError::SEVERITY_LOW;
+                    break;
+
+                default:
+                    $message = 'Class ' . $error['class'] . ' invalid/missing a docblock.';
+                    $severity = BuildError::SEVERITY_LOW;
+                    break;
             }
 
             $this->build->reportError(


### PR DESCRIPTION
This PR logs the error from the PHPDocBlockChecker rather than just logging that the doc block is missing.

## Contribution type

Feature

## Description of change

Previously when the docblock checker failed, it would just log that the docblock was missing rather than the actual message coming back from the plugin.
