### PR TITLE
feature: check localization command

### DIFF
--- a/src/Command/CheckLocalizationCommand.php
+++ b/src/Command/CheckLocalizationCommand.php
@@ -60,8 +60,8 @@ class CheckLocalizationCommand extends Command
         $output->writeln('<info>Check localizations!</info>');
         $output->writeln('');
 
-        $sameThanEnglish = (isset($input->getOption('same'))) ? $input->getOption('same') : false;
-        $languagesList = (isset($input->getOption('langs'))) ? explode(',', $input->getOption('langs')) : [];
+        $sameThanEnglish = (null !== $input->getOption('same')) ? $input->getOption('same') : false;
+        $languagesList = (null !== $input->getOption('langs')) ? explode(',', $input->getOption('langs')) : [];
 
         // Get English version
         $english = $this->getTranslations($this->basePath.'/lang.en.php');

--- a/src/Command/CheckLocalizationCommand.php
+++ b/src/Command/CheckLocalizationCommand.php
@@ -50,6 +50,9 @@ class CheckLocalizationCommand extends Command
 
     /**
      * Loops through running.
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -57,8 +60,8 @@ class CheckLocalizationCommand extends Command
         $output->writeln('<info>Check localizations!</info>');
         $output->writeln('');
 
-        $sameThanEnglish = $input->getOption('same') ?? false;
-        $languagesList = (null !== $input->getOption('langs')) ? explode(',', $input->getOption('langs')) : [];
+        $sameThanEnglish = (isset($input->getOption('same'))) ? $input->getOption('same') : false;
+        $languagesList = (isset($input->getOption('langs'))) ? explode(',', $input->getOption('langs')) : [];
 
         // Get English version
         $english = $this->getTranslations($this->basePath.'/lang.en.php');

--- a/src/Command/CheckLocalizationCommand.php
+++ b/src/Command/CheckLocalizationCommand.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace PHPCensor\Command;
+
+use Monolog\Logger;
+use PHPCensor\Service\BuildService;
+use PHPCensor\Store\Factory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Check localizations.
+ */
+class CheckLocalizationCommand extends Command
+{
+    /**
+     * @var array
+     */
+    protected $excluded = ['lang.en.php'];
+
+    /**
+     * Construct.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->basePath = __DIR__.'/../Languages';
+    }
+
+    /**
+     * Configure.
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('php-censor:check-localizations')
+            ->addOption('same', 0, InputOption::VALUE_OPTIONAL, 'Same than English version (0 = no, 1 = yes)')
+            ->addOption(
+                'langs',
+                [],
+                InputOption::VALUE_OPTIONAL,
+                'List of languages separated by commas. By default, all languages'
+            )
+            ->setDescription('Check localizations.');
+    }
+
+    /**
+     * Loops through running.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('');
+        $output->writeln('<info>Check localizations!</info>');
+        $output->writeln('');
+
+        $sameThanEnglish = $input->getOption('same') ?? false;
+        $languagesList = (null !== $input->getOption('langs')) ? explode(',', $input->getOption('langs')) : [];
+
+        // Get English version
+        $english = $this->getTranslations($this->basePath.'/lang.en.php');
+
+        $othersLanguages = $this->getLanguages($languagesList);
+
+        $diffs = $this->compareTranslations($english, $othersLanguages);
+
+        foreach ($diffs as $language => $value) {
+            $output->writeln('');
+            $output->writeln($language.' : ');
+            if (!empty($value['not_present'])) {
+                $output->writeln('    * not present : '.implode(', ', $value['not_present']));
+            }
+
+            if ($sameThanEnglish === '1' && !empty($value['same'])) {
+                $output->writeln('    * same than English : '.implode(', ', $value['same']));
+            }
+            $output->writeln('');
+        }
+    }
+
+    /**
+     * Returns array of translations by language.
+     *
+     * @param string $language language code
+     *
+     * @return array
+     */
+    private function getTranslations($language)
+    {
+        return [
+            include($language)
+        ];
+    }
+
+    /**
+     * Returns list of languages.
+     *
+     * @param array $languagesList
+     *
+     * @return array
+     */
+    private function getLanguages(array $languagesList = [])
+    {
+        $files = glob($this->basePath.'/*.php');
+
+        $languages = array_map(function ($dir) use ($languagesList) {
+            $name = basename($dir);
+
+            // Not exclused
+            if (in_array($name, $this->excluded, true)) {
+                return null;
+            }
+
+            // Check if in list of languages.
+            if (!empty($languagesList)) {
+                $languageOfName = explode('.', $name);
+
+                if (null == $languageOfName[1] || !in_array($languageOfName[1], $languagesList)) {
+                    return null;
+                }
+            }
+
+            return $name;
+        }, $files);
+
+        return array_filter($languages);
+    }
+
+    /**
+     * Compare translations.
+     *
+     * @param array $default   language by default
+     * @param array $languages others languages
+     *
+     * @return array
+     */
+    private function compareTranslations(array $default, array $languages)
+    {
+        $diffs = [];
+
+        // Return diff language by language
+        foreach ($languages as $language) {
+            $current = $this->getTranslations($this->basePath.'/'.$language);
+
+            foreach ($default as $key => $values) {
+                $keyValues = array_keys($values);
+
+                foreach ($keyValues as $key2) {
+                    if (!isset($current[$key][$key2])) {
+                        $diffs[$language]['not_present'][] = $key2;
+                    } elseif ($current[$key][$key2] === $default[$key][$key2]) {
+                        $diffs[$language]['same'][] = $key2;
+                    }
+                }
+            }
+        }
+
+        return $diffs;
+    }
+}

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -2,11 +2,10 @@
 
 namespace PHPCensor\Console;
 
-use PHPCensor\Config;
-use PHPCensor\Store\Factory;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use PHPCensor\Command\CheckLocalizationCommand;
 use PHPCensor\Command\CreateAdminCommand;
 use PHPCensor\Command\CreateBuildCommand;
 use PHPCensor\Command\InstallCommand;
@@ -15,17 +14,19 @@ use PHPCensor\Command\RebuildQueueCommand;
 use PHPCensor\Command\RunCommand;
 use PHPCensor\Command\ScheduleBuildCommand;
 use PHPCensor\Command\WorkerCommand;
+use PHPCensor\Config;
 use PHPCensor\Logging\Handler;
 use PHPCensor\Service\BuildService;
 use PHPCensor\Store\BuildStore;
+use PHPCensor\Store\Factory;
 use PHPCensor\Store\ProjectStore;
 use PHPCensor\Store\UserStore;
-use Symfony\Component\Console\Application as BaseApplication;
+use Phinx\Config\Config as PhinxConfig;
 use Phinx\Console\Command\Create;
 use Phinx\Console\Command\Migrate;
 use Phinx\Console\Command\Rollback;
 use Phinx\Console\Command\Status;
-use Phinx\Config\Config as PhinxConfig;
+use Symfony\Component\Console\Application as BaseApplication;
 
 /**
  * Class Application
@@ -148,6 +149,7 @@ LOGO;
         $this->add(new WorkerCommand($logger));
         $this->add(new RebuildQueueCommand($logger));
         $this->add(new ScheduleBuildCommand($projectStore, $buildStore, new BuildService($buildStore)));
+        $this->add(new CheckLocalizationCommand());
     }
 
     public function getHelp()

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -152,6 +152,11 @@ LOGO;
         $this->add(new CheckLocalizationCommand());
     }
 
+    /**
+     * Returns help.
+     *
+     * @return string
+     */
     public function getHelp()
     {
         return self::LOGO . parent::getHelp();


### PR DESCRIPTION
## Contribution type

new feature on resources

## Description of change

A command to check localization files, with English version :

```
bin/console php-censor:check-localizations
```

You can choose languages list (separated by commas) with "lang" option :

```
bin/console php-censor:check-localizations --langs=fr,ru
```

If you need tags with same translations than English version, vous can choose the "same" option :

```
bin/console php-censor:check-localizations --same=1
```

And you can combine options :

```
bin/console php-censor:check-localizations --langs=fr,ru --same=1
```