### PR TITLE
Installing HipChat via composer

### DIFF
--- a/docs/en/plugins/hipchat_notify.md
+++ b/docs/en/plugins/hipchat_notify.md
@@ -4,6 +4,13 @@ Plugin Hipchat Notify
 This plugin joins a [HipChat](https://www.hipchat.com/) room and sends a user-defined message, for example a 
 "Build Succeeded" message.
 
+Install via Composer
+--------------------
+```
+cd /var/www/php-censor
+composer require "hipchat/hipchat-php"
+```
+
 Configuration
 -------------
 


### PR DESCRIPTION
I was getting the following error:
Class 'HipChat\HipChat' not found

After checking composer.json I saw the `suggest` packages. 

Good to have in the documentation.

## Contribution type

Documentation for Hipchat Plugin

## Description of change

Directions on how to install HipChat with composer
