### PR TITLE
fix: make directory for local build

### DIFF
--- a/src/Model/Build/LocalBuild.php
+++ b/src/Model/Build/LocalBuild.php
@@ -48,8 +48,8 @@ class LocalBuild extends Build
         if (isset($buildSettings['prefer_symlink']) && $buildSettings['prefer_symlink'] === true) {
             return $this->handleSymlink($builder, $reference, $buildPath);
         } else {
-            $cmd = 'cp -Rf "%s" "%s/"';
-            $builder->executeCommand($cmd, $reference, $buildPath);
+            $cmd = 'mkdir -p "%s" && cp -Rf "%s" "%s/"';
+            $builder->executeCommand($cmd, $buildPath, $reference, $buildPath);
         }
 
         return true;


### PR DESCRIPTION
## Contribution type

Bug fix

## Description of change

When I add a "Local path" project, on a Debian server, I have a problem because the system can copy my files in unknown directory.
