### PR TITLE
Explain the default value of new options in PHP CS Fixer plugin

### DIFF
--- a/docs/en/plugins/php_cs_fixer.md
+++ b/docs/en/plugins/php_cs_fixer.md
@@ -15,7 +15,7 @@ Configuration
 * **args** [string, optional] - Command line args (in string format) to pass to PHP Coding Standards Fixer (default: ``)
 * **config** [string, optional] - Special config file (default: `%BUILD_PATH%./.php_cs` or `%BUILD_PATH%./.php_cs.dist`)
 * **errors** [bool, optional] - Not fix files, but get the number of files with problem (default: false)
-* **report-errors** [bool, optional] - With **errors**, get the list of files in "Errors" tab (default: false)
+* **report_errors** [bool, optional] - With **errors**, get the list of files in "Errors" tab (default: false)
 
 ### Examples
 

--- a/docs/en/plugins/php_cs_fixer.md
+++ b/docs/en/plugins/php_cs_fixer.md
@@ -14,8 +14,8 @@ Configuration
 * **rules** [string, optional] - Fixer rules (default: `@PSR2`)
 * **args** [string, optional] - Command line args (in string format) to pass to PHP Coding Standards Fixer (default: ``)
 * **config** [string, optional] - Special config file (default: `%BUILD_PATH%./.php_cs` or `%BUILD_PATH%./.php_cs.dist`)
-* **errors** [bool, optional] - Not fix files, but get the number of files with problem
-* **report-errors** [bool, optional] - With **errors**, get the list of files in "Errors" tab
+* **errors** [bool, optional] - Not fix files, but get the number of files with problem (default: false)
+* **report-errors** [bool, optional] - With **errors**, get the list of files in "Errors" tab (default: false)
 
 ### Examples
 

--- a/src/Plugin/PhpCsFixer.php
+++ b/src/Plugin/PhpCsFixer.php
@@ -28,6 +28,11 @@ class PhpCsFixer extends Plugin
     protected $fileErrors = 'tmp_php-cs-fixer.log';
 
     /**
+     * @var int
+     */
+    protected $allowedWarnings;
+
+    /**
      * @return string
      */
     public static function pluginName()

--- a/src/Plugin/PhpCsFixer.php
+++ b/src/Plugin/PhpCsFixer.php
@@ -76,7 +76,7 @@ class PhpCsFixer extends Plugin
             $this->errors = true;
             $this->args .= ' --dry-run';
 
-            if (isset($options['report-errors']) && $options['report-errors']) {
+            if (isset($options['report_errors']) && $options['report_errors']) {
                 $this->reportErrors = true;
             }
 


### PR DESCRIPTION
## Contribution type

Bugfix

## Description of change

- Explain the default value of new options in PHP CS Fixer plugin
- added previously dynamically declared `$allowedWarnings` property
- rename option `report-errors` to `report_errors`