### PR TITLE
User Listing Edit Bug

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -51,8 +51,6 @@ class UserController extends WebController
     */
     public function index()
     {
-        $this->requireAdmin();
-
         $users               = $this->userStore->getWhere([], 1000, 0, ['email' => 'ASC']);
         $this->view->users   = $users;
         $this->layout->title = Lang::get('manage_users');
@@ -206,10 +204,14 @@ class UserController extends WebController
     */
     public function edit($userId)
     {
-        $this->requireAdmin();
+        $currentUser = $this->getUser();
 
         $method = $this->request->getMethod();
         $user   = $this->userStore->getById($userId);
+
+        if (!$currentUser->getIsAdmin() && $currentUser != $user) {
+            throw new ForbiddenException('You do not have permission to do that.');
+        }
 
         if (empty($user)) {
             throw new NotFoundException(Lang::get('user_n_not_found', $userId));
@@ -233,7 +235,12 @@ class UserController extends WebController
         $name     = $this->getParam('name', null);
         $email    = $this->getParam('email', null);
         $password = $this->getParam('password', null);
-        $isAdmin  = (boolean)$this->getParam('is_admin', 0);
+
+        // Only admins can promote/demote users.
+        $isAdmin = $user->getIsAdmin();
+        if ($currentUser->getIsAdmin()) {
+            $isAdmin = (boolean) $this->getParam('is_admin', 0);
+        }
 
         $this->userService->updateUser($user, $name, $email, $password, $isAdmin);
 
@@ -247,6 +254,8 @@ class UserController extends WebController
     */
     protected function userForm($values, $type = 'add')
     {
+        $currentUser = $this->getUser();
+
         $form = new Form();
 
         $form->setMethod('POST');
@@ -282,12 +291,14 @@ class UserController extends WebController
         $field->setContainerClass('form-group');
         $form->addField($field);
 
-        $field = new Form\Element\Checkbox('is_admin');
-        $field->setRequired(false);
-        $field->setCheckedValue(1);
-        $field->setLabel(Lang::get('is_user_admin'));
-        $field->setContainerClass('form-group');
-        $form->addField($field);
+        if ($currentUser->getIsAdmin()) {
+            $field = new Form\Element\Checkbox('is_admin');
+            $field->setRequired(false);
+            $field->setCheckedValue(1);
+            $field->setLabel(Lang::get('is_user_admin'));
+            $field->setContainerClass('form-group');
+            $form->addField($field);
+        }
 
         $field = new Form\Element\Submit();
         $field->setValue(Lang::get('save_user'));

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -51,6 +51,8 @@ class UserController extends WebController
     */
     public function index()
     {
+        $this->requireAdmin();
+
         $users               = $this->userStore->getWhere([], 1000, 0, ['email' => 'ASC']);
         $this->view->users   = $users;
         $this->layout->title = Lang::get('manage_users');

--- a/src/View/User/index.phtml
+++ b/src/View/User/index.phtml
@@ -2,12 +2,14 @@
 
 use PHPCensor\Helper\Lang;
 
-$user = $this->getUser();
+$currentUser = $this->getUser();
 
 ?>
 <div class="clearfix"  style="margin-bottom: 20px;">
     <div class="pull-right btn-group">
+        <?php if($currentUser->getIsAdmin()): ?>
         <a class="btn btn-success" href="<?= APP_URL; ?>user/add"><?= Lang::get('add_user'); ?></a>
+        <?php endif; ?>
     </div>
 </div>
 
@@ -41,21 +43,34 @@ $user = $this->getUser();
                         }
                         ?>
                         <tr class="<?= $cls; ?>">
-                            <td><a href="<?= APP_URL; ?>user/edit/<?= $user->getId(); ?>"><?= $user->getEmail(); ?></a></td>
+                            <td>
+                                <?php if($currentUser->getIsAdmin() || $currentUser == $user): ?>
+                                <a href="<?= APP_URL; ?>user/edit/<?= $user->getId(); ?>"><?= $user->getEmail(); ?></a>
+                                <?php else: ?>
+                                <?= $user->getEmail(); ?>
+                                <?php endif; ?>
+                            </td>
                             <td><?= htmlspecialchars($user->getName()); ?></td>
                             <td><?= $status; ?></td>
                             <td>
-                                <?php if($user->getIsAdmin()): ?>
-                                    <div class="btn-group btn-group-right">
-                                        <a class="btn btn-default btn-sm" href="<?= APP_URL; ?>user/edit/<?= $user->getId(); ?>"><?= Lang::get('edit'); ?></a>
-                                        <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
-                                            <span class="caret"></span>
-                                        </button>
-                                        <ul class="dropdown-menu">
-                                            <li><a href="<?= APP_URL; ?>user/delete/<?= $user->getId(); ?>" class="delete-user"><?= Lang::get('delete_user'); ?></a></li>
-                                        </ul>
-                                    </div>
-                                <?php endif; ?>
+                                <div class="btn-group btn-group-right">
+                                    <?php if($currentUser->getIsAdmin() || $currentUser == $user): ?>
+                                    <a class="btn btn-default btn-sm"
+                                        href="<?= APP_URL; ?>user/edit/<?= $user->getId(); ?>">
+                                        <?= Lang::get('edit'); ?>
+                                    </a>
+                                    <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
+                                        <span class="caret"></span>
+                                    </button>
+                                    <?php endif; ?>
+
+                                    <?php if($currentUser->getIsAdmin()): ?>
+                                    <ul class="dropdown-menu">
+                                        <li><a href="<?= APP_URL; ?>user/delete/<?= $user->getId(); ?>"
+                                            class="delete-user"><?= Lang::get('delete_user'); ?></a></li>
+                                    </ul>
+                                    <?php endif; ?>
+                                </div>
                             </td>
                         </tr>
                     <?php endforeach; ?>


### PR DESCRIPTION
## Contribution type

Bug Fix

## Description of change

On the user listing page, the ```$user``` variable is getting clobbered by the foreach loop resulting in admins only being allowed to edit/delete other admins.

~~Also, the user listing page probably shouldn't be visible by non-admins. Users can still edit their own profile using the link in the top right drop down.~~

Although users can see the /user listing, they can only edit themselves.
