### PR TITLE
Workaround for issue #217

### DIFF
--- a/src/Helper/CommandExecutor.php
+++ b/src/Helper/CommandExecutor.php
@@ -140,31 +140,26 @@ class CommandExecutor implements CommandExecutorInterface
             stream_set_blocking($descriptor, false);
             $outputs[$key] = '';
         }
-        $nretries = 6;
+        $retries = 6;
         $timeout = 15;
-        //$tmpfile = '/tmp/READALTERNATING_'.date('Y-m-d-H-i-s');
-        //file_put_contents($tmpfile, "Starting ...\n");
         do {
-            for ($i = 0; $i < $nretries; ++$i) {
+            $resources = 0;
+            for ($i = 0; $i < $retries; ++$i) {
                 $read = $descriptors;
                 $write = null;
                 $except = null;
-                $nresources = stream_select($read, $write, $except, $timeout);
-                if (intval($nresources) > 0) {
+                $resources = stream_select($read, $write, $except, $timeout);
+                if (intval($resources) > 0) {
                     break;
                 }
             }
-            //file_put_contents($tmpfile, 'nresources: '.$nresources."\n", FILE_APPEND);
-
             foreach ($read as $descriptor) {
-                //file_put_contents($tmpfile, 'reading descriptor: '.$descriptor."\n", FILE_APPEND);
                 $key = array_search($descriptor, $descriptors);
                 if (feof($descriptor)) {
                     fclose($descriptor);
                     unset($descriptors[$key]);
                 } else {
                     $buffer = fgets($descriptor);
-                    //file_put_contents($tmpfile, 'buffer: '.$buffer."\n", FILE_APPEND);
                     if ($buffer === false) {
                         fclose($descriptor);
                         unset($descriptors[$key]);
@@ -173,8 +168,7 @@ class CommandExecutor implements CommandExecutorInterface
                     $outputs[$key] .= $buffer;
                 }
             }
-            //file_put_contents($tmpfile, 'count(descriptors): '.count($descriptors)."\n", FILE_APPEND);
-        } while (count($descriptors) > 0 && intval($nresources) > 0);
+        } while (count($descriptors) > 0 && intval($resources) > 0);
         return $outputs;
     }
 

--- a/src/Helper/CommandExecutor.php
+++ b/src/Helper/CommandExecutor.php
@@ -140,21 +140,41 @@ class CommandExecutor implements CommandExecutorInterface
             stream_set_blocking($descriptor, false);
             $outputs[$key] = '';
         }
+        $nretries = 6;
+        $timeout = 15;
+        //$tmpfile = '/tmp/READALTERNATING_'.date('Y-m-d-H-i-s');
+        //file_put_contents($tmpfile, "Starting ...\n");
         do {
-            $read = $descriptors;
-            $write = null;
-            $except = null;
-            stream_select($read, $write, $except, null);
+            for ($i = 0; $i < $nretries; ++$i) {
+                $read = $descriptors;
+                $write = null;
+                $except = null;
+                $nresources = stream_select($read, $write, $except, $timeout);
+                if (intval($nresources) > 0) {
+                    break;
+                }
+            }
+            //file_put_contents($tmpfile, 'nresources: '.$nresources."\n", FILE_APPEND);
+
             foreach ($read as $descriptor) {
+                //file_put_contents($tmpfile, 'reading descriptor: '.$descriptor."\n", FILE_APPEND);
                 $key = array_search($descriptor, $descriptors);
                 if (feof($descriptor)) {
                     fclose($descriptor);
                     unset($descriptors[$key]);
                 } else {
-                    $outputs[$key] .= fgets($descriptor);
+                    $buffer = fgets($descriptor);
+                    //file_put_contents($tmpfile, 'buffer: '.$buffer."\n", FILE_APPEND);
+                    if ($buffer === false) {
+                        fclose($descriptor);
+                        unset($descriptors[$key]);
+                        continue;
+                    }
+                    $outputs[$key] .= $buffer;
                 }
             }
-        } while (count($descriptors) > 0);
+            //file_put_contents($tmpfile, 'count(descriptors): '.count($descriptors)."\n", FILE_APPEND);
+        } while (count($descriptors) > 0 && intval($nresources) > 0);
         return $outputs;
     }
 

--- a/src/Helper/CommandExecutor.php
+++ b/src/Helper/CommandExecutor.php
@@ -144,6 +144,7 @@ class CommandExecutor implements CommandExecutorInterface
         $timeout = 15;
         do {
             $resources = 0;
+            $read = [];
             for ($i = 0; $i < $retries; ++$i) {
                 $read = $descriptors;
                 $write = null;


### PR DESCRIPTION
The idea of this pull request is not to merge, but to provide some insight into solving issue #217.

I started by analyzing `fgets` behavior ---which may return `false` on error, but that value is not being checked by the code on master.

Since for Codeception's case I noticed that the `while` condition is still true after Codeception finishes, I tried checking the return value of the `stream_select` function.
* With a `null` timeout, or `$timeout = 1;`, the `stream_select` is still blocking indefinitely
* Using a `$timeout = 60;`, I noticed  that `stream_select` returns `1` when Codeception announces it's powered by PHPUnit, returns `0` right before the first test, and then it keeps returning `1` up until Codeception finishes
* In order to use `stream_select`'s return value as part of the `while` condition, and also accounting for the possible `0` return, I reduced the timeout and used a loop.

Right now, with this code in place, Codeception runs and PHP Censor is able to detect when it's finished (after 90 seconds).  It's not an elegant solution, but it works.

One thing though: even with the `--xml` flag positioned correctly (in `src/Plugin/Codeception.php`) , the artifacts directory is not created for the build, and the Information tab in the web view doesn't show any details for the tests.
