### PR TITLE
Moved the --xml flag to the end of the command

### DIFF
--- a/src/Plugin/Codeception.php
+++ b/src/Plugin/Codeception.php
@@ -122,7 +122,7 @@ class Codeception extends Plugin implements ZeroConfigPluginInterface
             return false;
         }
 
-        $cmd = 'cd "%s" && ' . $codeception . ' run -c "%s" --xml ' . $this->args;
+        $cmd = 'cd "%s" && ' . $codeception . ' run -c "%s" ' . $this->args . ' --xml';
 
         $configPath = $this->builder->buildPath . $configPath;
         $success = $this->builder->executeCommand($cmd, $this->builder->buildPath, $configPath);


### PR DESCRIPTION
## Contribution type

* Bug fix

## Description of change

The `--xml` flag can, optionally, get the name of the report to be generated.

When the args passed to PHP Censor for the Codeception plugin start with a non-flag (e.g., if the value of `test.codeception.args` is `"acceptance --coverage-html --html"`, then the codeception will end up running all the suites (instead of running only the desired one), and generating an XML report named `tests/_output/acceptance`.

Since PHP Censor looks explicitly for `tests/{_output,_log}/report.xml`, the test step will always fail.

Therefore, it's safer to insert the `--xml` flag at the end.