### PR TITLE
Remove verbose flag from Codeception's command line

### DIFF
--- a/src/Plugin/Codeception.php
+++ b/src/Plugin/Codeception.php
@@ -143,7 +143,7 @@ class Codeception extends Plugin implements ZeroConfigPluginInterface
 
         chdir($this->directory);
 
-        $cmd = 'cd "%s" && ' . $codeception . ' run -c "%s" ' . $this->args . ' --xml -vvv';
+        $cmd = 'cd "%s" && ' . $codeception . ' run -c "%s" ' . $this->args . ' --xml';
 
         $success = $this->builder->executeCommand($cmd, $this->directory, $this->ymlConfigFile);
 


### PR DESCRIPTION
## Contribution type

Bug fix.

Fixes #247.

## Description of change

I initially thought Codeception was inheriting the `SHELL_VERBOSITY` environment variable, but upon inspecting commit 5f914d5, I noticed `-vvv` was added explicitly. So issue #247 is not really related to issue #212.

For Codeception, the `-vvv` option implies `--steps`, which means that the email sent when the build fails at the testing phase will be huge (in my case, a suite of 80 tests, with ~40 steps per test, results in an email of more than 3200 lines).

The user can always pass `-vvv` as an argument for Codeception using the project's configuration ---but there's no option to remove unwanted verbosity.
