### PR TITLE
Reimplement executeCommand

### DIFF
--- a/src/Helper/CommandExecutor.php
+++ b/src/Helper/CommandExecutor.php
@@ -4,6 +4,7 @@ namespace PHPCensor\Helper;
 
 use Exception;
 use PHPCensor\Logging\BuildLogger;
+use Symfony\Component\Process\Process;
 
 /**
  * Handles running system commands with variables.
@@ -50,6 +51,15 @@ class CommandExecutor implements CommandExecutorInterface
     protected $buildPath;
 
     /**
+     * Commands with no proper exit mechanism
+     *
+     * @var array
+     */
+    private static $noExitCommands = [
+        'codecept',
+    ];
+
+    /**
      * @param BuildLogger $logger
      * @param string      $rootDir
      * @param bool        $verbose
@@ -79,28 +89,44 @@ class CommandExecutor implements CommandExecutorInterface
 
         $this->logger->logDebug('Command: ' . $command);
 
-        $status         = 0;
-        $descriptorSpec = [
-            0 => ["pipe", "r"], // stdin
-            1 => ["pipe", "w"], // stdout
-            2 => ["pipe", "w"], // stderr
-        ];
-
-        $pipes   = [];
-        $process = proc_open($command, $descriptorSpec, $pipes, $this->buildPath, null);
-
-        $lastOutput = '';
-        $lastError  = '';
-        if (is_resource($process)) {
-            fclose($pipes[0]);
-
-            list($lastOutput, $lastError) = $this->readAlternating([$pipes[1], $pipes[2]]);
-
-            $status = (int)proc_close($process);
-
-            $lastOutput = $this->replaceIllegalCharacters($lastOutput);
-            $lastError  = $this->replaceIllegalCharacters($lastError);
+        $withNoExit = '';
+        foreach (self::$noExitCommands as $nec) {
+            if (preg_match("/\b{$nec}\b/", $command)) {
+                $withNoExit = $nec;
+                break;
+            }
         }
+
+        $process = new Process($command, $this->buildPath);
+        $process->setTimeout(86400);
+
+        if (!empty($withNoExit)) {
+            $process->start();
+
+            $this->logger->logDebug("Assuming command '{$withNoExit}' does not exit properly");
+            sleep(15);
+            for (;;) {
+                $response = [];
+                exec("ps auxww | grep '{$withNoExit}' | grep -v grep", $response);
+                $response = array_filter($response, function ($a) {
+                    return strpos($a, $this->buildPath) !== false;
+                });
+
+                if (empty($response)) {
+                    $process->stop();
+                    break;
+                }
+                sleep(15);
+            }
+            $status = 0;
+        } else {
+            $process->setIdleTimeout(600);
+            $process->start();
+            $status = $process->wait();
+        }
+
+        $lastOutput = $this->replaceIllegalCharacters($process->getOutput());
+        $lastError = $this->replaceIllegalCharacters($process->getErrorOutput());
 
         $this->lastOutput = array_filter(explode(PHP_EOL, $lastOutput));
         $this->lastError  = $lastError;
@@ -123,56 +149,6 @@ class CommandExecutor implements CommandExecutorInterface
         $this->logger->logDebug('Execution status: ' . $status);
 
         return $isSuccess;
-    }
-
-    /**
-     * Reads from array of streams as data becomes available.
-     *
-     * @param array $descriptors
-     *
-     * @return string[] data read from each descriptor
-     */
-    private function readAlternating(array $descriptors)
-    {
-        $outputs = [];
-        foreach ($descriptors as $key => $descriptor) {
-            stream_set_blocking($descriptor, false);
-            $outputs[$key] = '';
-        }
-        
-        // 20 retries for 15 seconds = 5 min
-        $retries = 20;
-        $timeout = 15;
-        do {
-            $resources = 0;
-            $read      = [];
-            for ($i = 0; $i < $retries; ++$i) {
-                $read      = $descriptors;
-                $write     = null;
-                $except    = null;
-                $resources = stream_select($read, $write, $except, $timeout);
-                if (intval($resources) > 0) {
-                    break;
-                }
-            }
-            foreach ($read as $descriptor) {
-                $key = array_search($descriptor, $descriptors);
-                if (feof($descriptor)) {
-                    fclose($descriptor);
-                    unset($descriptors[$key]);
-                } else {
-                    $buffer = fgets($descriptor);
-                    if (false === $buffer) {
-                        fclose($descriptor);
-                        unset($descriptors[$key]);
-                        continue;
-                    }
-                    $outputs[$key] .= $buffer;
-                }
-            }
-        } while (count($descriptors) > 0 && intval($resources) > 0);
-
-        return $outputs;
     }
 
     /**

--- a/src/Helper/CommandExecutor.php
+++ b/src/Helper/CommandExecutor.php
@@ -104,20 +104,18 @@ class CommandExecutor implements CommandExecutorInterface
             $process->start();
 
             $this->logger->logDebug("Assuming command '{$withNoExit}' does not exit properly");
-            sleep(15);
-            for (;;) {
+            do {
+                sleep(15);
                 $response = [];
                 exec("ps auxww | grep '{$withNoExit}' | grep -v grep", $response);
-                $response = array_filter($response, function ($a) {
-                    return strpos($a, $this->buildPath) !== false;
-                });
-
-                if (empty($response)) {
-                    $process->stop();
-                    break;
-                }
-                sleep(15);
-            }
+                $response = array_filter(
+                    $response,
+                    function ($a) {
+                        return strpos($a, $this->buildPath) !== false;
+                    }
+                );
+            } while (!empty($response));
+            $process->stop();
             $status = 0;
         } else {
             $process->setIdleTimeout(600);
@@ -126,7 +124,7 @@ class CommandExecutor implements CommandExecutorInterface
         }
 
         $lastOutput = $this->replaceIllegalCharacters($process->getOutput());
-        $lastError = $this->replaceIllegalCharacters($process->getErrorOutput());
+        $lastError  = $this->replaceIllegalCharacters($process->getErrorOutput());
 
         $this->lastOutput = array_filter(explode(PHP_EOL, $lastOutput));
         $this->lastError  = $lastError;

--- a/src/Plugin/Codeception.php
+++ b/src/Plugin/Codeception.php
@@ -183,6 +183,10 @@ class Codeception extends Plugin implements ZeroConfigPluginInterface
             'failures'  => $parser->getTotalFailures(),
         ];
 
+        // NOTE: Codeception does not use stderr, so failure can only be detected
+        // through tests
+        $success = $success && (intval($meta['failures']) < 1);
+
         $this->build->storeMeta((self::pluginName() . '-meta'), $meta);
         $this->build->storeMeta((self::pluginName() . '-data'), $output);
         $this->build->storeMeta((self::pluginName() . '-errors'), $parser->getTotalFailures());


### PR DESCRIPTION
## Contribution type

*Bug fix*

## Description of change

Although pull request #229 solves the issue of builds never finishing  when using Codeception (issue #217), it does so in a sub-optimal way.

In general, the issue is that when Codeception finishes, *stdout* remains open, so PHP Censor assumes the process is still running.

Taking into account that PHP Censor already lists Symfony's Process component as a dependency, I reimplemented the `executeCommand` method to use said component for collecting the output of the process being executed, while checking periodically if the process is still running.

Symfony's Process default timeout is 60 seconds, so I changed it to a 86400, just to be sure it won't be an issue.  There's also an *idle* timeout, which I set to 600 seconds.

Codeception doesn't seem to use *stderr*, so in order to detect actual failure in the testing phase, the number of failed tests is used.
