### PR TITLE
Pahout plugin support

### DIFF
--- a/docs/en/plugins/pahout.md
+++ b/docs/en/plugins/pahout.md
@@ -1,0 +1,42 @@
+Plugin Pahout
+===========
+
+Runs [Pahout](https://github.com/wata727/pahout/) against your build.
+
+Configuration
+-------------
+
+### Options
+
+* **directory** [string, optional] - This option lets you specify the tests directory to run (default: `./src`).
+* **allowed_warnings** [int, optional] - Allow `n` warnings in a successful build (default: -1). 
+  Use -1 to allow unlimited warnings.
+  
+### Examples
+
+```yaml
+test:
+  pahout: ~
+```
+
+### Additional Options
+
+The following general options can also be used: 
+
+* **allow_failures** [bool, optional] - If true, allow the build to succeed even if this plugin fails.
+* **ignore** [optional] - A list of files / paths to ignore (default: build_settings > ignore).
+* **binary_name** [string|array, optional] - Allows you to provide a name of the binary.
+* **binary_path** [string, optional] - Allows you to provide a path to the binary vendor/bin, or a system-provided.
+* **priority_path** [string, optional] - Priority path for locating the plugin binary (Allowable values: 
+  `local` (Local current build path) | 
+  `global` (Global PHP Censor 'vendor/bin' path) |
+  `system` (OS System binaries path, /bin:/usr/bin etc.). 
+  Default order: local -> global -> system)
+
+Warning
+-------
+
+Pahout requires the following environment:
+
+- PHP 7.1 or newer
+- [php-ast](https://github.com/nikic/php-ast) v0.1.7 or newer

--- a/src/Plugin/Pahout.php
+++ b/src/Plugin/Pahout.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace PHPCensor\Plugin;
+
+use PHPCensor;
+use PHPCensor\Builder;
+use PHPCensor\Model\Build;
+use PHPCensor\Model\BuildError;
+use PHPCensor\Plugin;
+
+/**
+ * A pair programming partner for writing better PHP.
+ * https://github.com/wata727/pahout
+ *
+ * Class Pahout
+ * @package PHPCensor\Plugin
+ */
+class Pahout extends Plugin
+{
+    /** @var string */
+    const TAB = "\t";
+
+    /** @var string */
+    protected $directory;
+
+    /** @var int */
+    protected $allowedWarnings;
+
+    /**
+     * Psalm constructor.
+     * @param Builder $builder
+     * @param Build $build
+     * @param array $options
+     * @throws \Exception
+     */
+    public function __construct(Builder $builder, Build $build, array $options = [])
+    {
+        parent::__construct($builder, $build, $options);
+
+        $this->executable = $this->findBinary('pahout');
+
+        if (!empty($options['directory']) && \is_string($options['directory'])) {
+            $this->directory = $options['directory'];
+        } else {
+            $this->directory = './src';
+        }
+
+        if (isset($options['allowed_warnings']) && \is_int($options['allowed_warnings'])) {
+            $this->allowedWarnings = $options['allowed_warnings'];
+        } else {
+            $this->allowedWarnings = -1;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function execute()
+    {
+        $pahout = $this->executable;
+
+        if ((!\defined('DEBUG_MODE') || !DEBUG_MODE) && !(boolean)$this->build->getExtra('debug')) {
+            $this->builder->logExecOutput(false);
+        }
+
+        $this->builder->executeCommand(
+            'cd "%s" && ' . $pahout . ' %s --format=json',
+            $this->builder->buildPath,
+            $this->directory
+        );
+        $this->builder->logExecOutput(true);
+
+        // Define that the plugin succeed
+        $success = true;
+
+        list($files, $hints) = $this->processReport($this->builder->getLastOutput());
+
+        if (0 < \count($hints)) {
+            if (-1 !== $this->allowedWarnings && \count($hints) > $this->allowedWarnings) {
+                $success = false;
+            }
+
+            foreach ($hints as $hint) {
+                $this->builder->logFailure('HINT: ' . $hint['full_message'] . \PHP_EOL);
+
+                $this->build->reportError(
+                    $this->builder,
+                    self::pluginName(),
+                    $hint['message'],
+                    BuildError::SEVERITY_LOW,
+                    $hint['file'],
+                    $hint['line_from']
+                );
+            }
+        }
+
+        if ($success) {
+            $this->builder->logSuccess('Awesome! There is nothing from me to teach you!');
+        }
+
+        $this->builder->log(\sprintf('%d files checked, %d hints detected.', \count($files), \count($hints)));
+
+        return $success;
+    }
+
+    /**
+     * @return string
+     */
+    public static function pluginName()
+    {
+        return 'pahout';
+    }
+
+    /**
+     * @param string $stage
+     * @param Build $build
+     * @return bool
+     */
+    public static function canExecuteOnStage($stage, Build $build)
+    {
+        return Build::STAGE_TEST === $stage;
+    }
+
+    /**
+     * @param string $output
+     * @return array
+     */
+    protected function processReport(string $output)
+    {
+        $data = \json_decode(trim($output), true);
+
+        $hints = [];
+        $files = [];
+
+        if (!empty($data) && \is_array($data) && isset($data['hints'])) {
+            $files = $data['files'];
+
+            foreach ($data['hints'] as $hint) {
+                $hints[] = [
+                    'full_message' => \vsprintf('%s:%d' . \PHP_EOL . self::TAB . '%s: %s [%s]', [
+                        $hint['filename'],
+                        $hint['lineno'],
+                        $hint['type'],
+                        $hint['message'],
+                        $hint['link']
+                    ]),
+                    'message' => $hint['message'],
+                    'file' => $hint['filename'],
+                    'line_from' => $hint['lineno']
+                ];
+            }
+        }
+
+        return [$files, $hints];
+    }
+}


### PR DESCRIPTION
[Pahout](https://github.com/wata727/pahout)

A pair programming partner for writing better PHP. Pahout means PHP mahout

```yml
test:
  pahout: ~
```
![image](https://user-images.githubusercontent.com/400362/52899947-c9467880-31f8-11e9-833a-de3c7cffba96.png)

```yml
test:
  pahout:
    directory: .
```
![image](https://user-images.githubusercontent.com/400362/52899975-2c380f80-31f9-11e9-826b-ea03bd9323d2.png)


```yml
test:
  pahout:
    directory: .
    allowed_warnings: 0
```
![image](https://user-images.githubusercontent.com/400362/52899999-820cb780-31f9-11e9-9d15-1a4a7b914a28.png)
![image](https://user-images.githubusercontent.com/400362/52900006-9650b480-31f9-11e9-92fa-79378f21bc33.png)

Pahout requires the following environment:

- PHP 7.1 or newer
- [php-ast](https://github.com/nikic/php-ast) v0.1.7 or newer