### PR TITLE
Phpstan support

### DIFF
--- a/docs/en/plugins/phpstan.md
+++ b/docs/en/plugins/phpstan.md
@@ -1,0 +1,44 @@
+Plugin PhpStan
+===========
+
+Runs [PhpStan](https://github.com/phpstan/phpstan) against your build.
+
+PHPStan focuses on finding errors in your code without actually running it. It catches whole classes of bugs
+even before you write tests for the code. It moves PHP closer to compiled languages in the sense that the correctness of each line of the code
+can be checked before you run the actual line.
+
+Configuration
+-------------
+
+### Options
+
+* **allowed_errors** [int, optional] - Allow `n` errors in a successful build (default: 0). 
+  Use -1 to allow unlimited warnings.
+  
+### Examples
+
+```yaml
+test:
+  phpstan: ~
+```
+
+### Additional Options
+
+The following general options can also be used: 
+
+* **allow_failures** [bool, optional] - If true, allow the build to succeed even if this plugin fails.
+* **directory** [string, optional] - This option lets you specify the tests directory to run.
+* **ignore** [optional] - A list of files / paths to ignore (default: build_settings > ignore).
+* **binary_name** [string|array, optional] - Allows you to provide a name of the binary.
+* **binary_path** [string, optional] - Allows you to provide a path to the binary vendor/bin, or a system-provided.
+* **priority_path** [string, optional] - Priority path for locating the plugin binary (Allowable values: 
+  `local` (Local current build path) | 
+  `global` (Global PHP Censor 'vendor/bin' path) |
+  `system` (OS System binaries path, /bin:/usr/bin etc.). 
+  Default order: local -> global -> system)
+
+Warning
+-------
+
+PHPStan requires PHP >= 7.1. You have to run it in environment with PHP 7.x but the actual code does not have to use
+PHP 7.x features. (Code written for PHP 5.6 and earlier can run on 7.x mostly unmodified.)

--- a/src/Plugin/PhpStan.php
+++ b/src/Plugin/PhpStan.php
@@ -80,7 +80,7 @@ class PhpStan extends Plugin
                         }
                         $out .= \vsprintf(' %d%s %s' . PHP_EOL, [
                             $message['line'],
-                            \str_repeat(' ', 6 - strlen($message['line'])),
+                            \str_repeat(' ', 6 - \strlen($message['line'])),
                             $message['message']
                         ]);
 
@@ -137,7 +137,7 @@ class PhpStan extends Plugin
      */
     protected function processReport(string $output)
     {
-        $data = \json_decode(trim($output), true);
+        $data = \json_decode(\trim($output), true);
 
         $total_errors = 0;
         $files = [];

--- a/src/Plugin/PhpStan.php
+++ b/src/Plugin/PhpStan.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace PHPCensor\Plugin;
+
+use PHPCensor;
+use PHPCensor\Builder;
+use PHPCensor\Model\Build;
+use PHPCensor\Model\BuildError;
+use PHPCensor\Plugin;
+
+/**
+ * PHPStan focuses on finding errors in your code without actually running it. It catches whole classes of bugs even
+ * before you write tests for the code. It moves PHP closer to compiled languages in the sense that the correctness of
+ * each line of the code can be checked before you run the actual line.
+ * https://github.com/phpstan/phpstan
+ *
+ * Class PhpStan
+ * @package PHPCensor\Plugin
+ */
+class PhpStan extends Plugin
+{
+    /** @var int */
+    protected $allowedErrors = 0;
+
+    /**
+     * Psalm constructor.
+     * @param Builder $builder
+     * @param Build $build
+     * @param array $options
+     * @throws \Exception
+     */
+    public function __construct(Builder $builder, Build $build, array $options = [])
+    {
+        parent::__construct($builder, $build, $options);
+
+        $this->executable = $this->findBinary('phpstan');
+
+        if (isset($options['allowed_errors']) && \is_int($options['allowed_errors'])) {
+            $this->allowedErrors = $options['allowed_errors'];
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function execute()
+    {
+        $phpstan = $this->executable;
+
+        if ((!\defined('DEBUG_MODE') || !DEBUG_MODE) && !(boolean)$this->build->getExtra('debug')) {
+            $this->builder->logExecOutput(false);
+        }
+
+        $this->builder->executeCommand(
+            'cd "%s" && ' . $phpstan . ' analyze --error-format=json',
+            $this->builder->buildPath
+        );
+        $this->builder->logExecOutput(true);
+
+        // Define that the plugin succeed
+        $success = true;
+
+        list($total_errors, $files) = $this->processReport($this->builder->getLastOutput());
+
+        if (0 < $total_errors) {
+            if (-1 !== $this->allowedErrors && $total_errors > $this->allowedErrors) {
+                $success = false;
+            }
+
+            foreach ($files as $file => $payload) {
+                if (0 < $payload['errors']) {
+                    $file = \str_replace($this->build->getBuildPath(), '', $file);
+                    $len = \strlen($file);
+                    $out = '';
+                    $filename = (false !== \strpos($file, ' (')) ? \strstr($file, ' (', true) : $file;
+
+                    foreach ($payload['messages'] as $message) {
+                        if (\strlen($message['message']) > $len) {
+                            $len = \strlen($message['message']);
+                        }
+                        $out .= \vsprintf(' %d%s %s' . PHP_EOL, [
+                            $message['line'],
+                            \str_repeat(' ', 6 - strlen($message['line'])),
+                            $message['message']
+                        ]);
+
+                        $this->build->reportError(
+                            $this->builder,
+                            self::pluginName(),
+                            $message['message'],
+                            BuildError::SEVERITY_NORMAL,
+                            $filename,
+                            $message['line']
+                        );
+                    }
+                    $separator = \str_repeat('-', 6) . ' ' . \str_repeat('-', $len + 2) . PHP_EOL;
+
+                    $this->builder->logFailure(\vsprintf('%s Line   %s' . PHP_EOL . '%s', [
+                        $separator,
+                        $file,
+                        $separator . $out . $separator
+                    ]));
+                }
+            }
+        }
+
+        if ($success) {
+            $this->builder->logSuccess('[OK] No errors');
+        } else {
+            $this->builder->log(\sprintf('[ERROR] Found %d errors', $total_errors));
+        }
+
+        return $success;
+    }
+
+    /**
+     * @return string
+     */
+    public static function pluginName()
+    {
+        return 'phpstan';
+    }
+
+    /**
+     * @param string $stage
+     * @param Build $build
+     * @return bool
+     */
+    public static function canExecuteOnStage($stage, Build $build)
+    {
+        return Build::STAGE_TEST === $stage;
+    }
+
+    /**
+     * @param string $output
+     * @return array
+     */
+    protected function processReport(string $output)
+    {
+        $data = \json_decode(trim($output), true);
+
+        $total_errors = 0;
+        $files = [];
+
+        if (!empty($data) && \is_array($data) && (0 < $data['totals']['file_errors'])) {
+            $total_errors = $data['totals']['file_errors'];
+            $files = $data['files'];
+        }
+
+        return [$total_errors, $files];
+    }
+}


### PR DESCRIPTION
Runs [PhpStan](https://github.com/phpstan/phpstan) against your build.

PHPStan focuses on finding errors in your code without actually running it. It catches whole classes of bugs even before you write tests for the code. It moves PHP closer to compiled languages in the sense that the correctness of each line of the code can be checked before you run the actual line.

PHPStan requires PHP >= 7.1. You have to run it in environment with PHP 7.x but the actual code does not have to use
PHP 7.x features. (Code written for PHP 5.6 and earlier can run on 7.x mostly unmodified.)

```yml
test:
  phpstan: ~
```
![image](https://user-images.githubusercontent.com/400362/52907243-3e9c6280-3266-11e9-99b1-34f294c6ea5d.png)
![image](https://user-images.githubusercontent.com/400362/52907248-52e05f80-3266-11e9-886f-213e89b899c9.png)

```yml
test:
  phpstan:
    allowed_errors: -1
```
![image](https://user-images.githubusercontent.com/400362/52907250-6ab7e380-3266-11e9-82d9-91f02616a227.png)


PhpStan also have plugins, the plugins I used for my current test was:
- [phpstan/phpstan-phpunit](https://github.com/phpstan/phpstan-phpunit)
- [phpstan/phpstan-strict-rules](https://github.com/phpstan/phpstan-strict-rules)
- [phpstan/phpstan-deprecation-rules](https://github.com/phpstan/phpstan-deprecation-rules)
- [phpstan/phpstan-php-parser](https://github.com/phpstan/phpstan-php-parser)
- [phpstan/phpstan-mockery](https://github.com/phpstan/phpstan-mockery)
- [phpstan/phpstan-beberlei-assert](https://github.com/phpstan/phpstan-beberlei-assert)

More plugins can be found [here](https://github.com/phpstan)

My **phpstan.neon** file for the project was:

```yml
includes:
  - /root/.composer/vendor/phpstan/phpstan-phpunit/extension.neon
  - /root/.composer/vendor/phpstan/phpstan-phpunit/rules.neon
  - /root/.composer/vendor/phpstan/phpstan-strict-rules/rules.neon
  - /root/.composer/vendor/phpstan/phpstan-deprecation-rules/rules.neon
  - /root/.composer/vendor/phpstan/phpstan-php-parser/extension.neon
  - /root/.composer/vendor/phpstan/phpstan-mockery/extension.neon
  - /root/.composer/vendor/phpstan/phpstan-beberlei-assert/extension.neon

parameters:
  level: max
  paths:
    - src
    - tests
```

[Example of **phpstan.neon** file](https://github.com/phpstan/phpstan/blob/master/build/phpstan.neon)