### PR TITLE
Phlint support

### DIFF
--- a/docs/en/plugins/phlint.md
+++ b/docs/en/plugins/phlint.md
@@ -1,0 +1,38 @@
+Plugin Phlint
+=============
+
+Runs [Phlint](https://gitlab.com/phlint/phlint) against your build.
+
+Phlint is a tool with an aim to help maintain quality of php code by analyzing code and pointing out potential code
+issues. It focuses on how the code works rather than how the code looks. Phlint is designed from the start to do
+deep semantic analysis rather than doing only shallow or stylistic analysis.
+
+Configuration
+-------------
+
+### Options
+
+* **allowed_errors** [int, optional] - Allow `n` errors in a successful build (default: 0). 
+  Use -1 to allow unlimited errors.
+  
+### Examples
+
+```yaml
+test:
+  phlint: ~
+```
+
+### Additional Options
+
+The following general options can also be used: 
+
+* **allow_failures** [bool, optional] - If true, allow the build to succeed even if this plugin fails.
+* **directory** [string, optional] - This option lets you specify the tests directory to run.
+* **ignore** [optional] - A list of files / paths to ignore (default: build_settings > ignore).
+* **binary_name** [string|array, optional] - Allows you to provide a name of the binary.
+* **binary_path** [string, optional] - Allows you to provide a path to the binary vendor/bin, or a system-provided.
+* **priority_path** [string, optional] - Priority path for locating the plugin binary (Allowable values: 
+  `local` (Local current build path) | 
+  `global` (Global PHP Censor 'vendor/bin' path) |
+  `system` (OS System binaries path, /bin:/usr/bin etc.). 
+  Default order: local -> global -> system)

--- a/src/Plugin/Phlint.php
+++ b/src/Plugin/Phlint.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace PHPCensor\Plugin;
+
+use PHPCensor;
+use PHPCensor\Builder;
+use PHPCensor\Model\Build;
+use PHPCensor\Model\BuildError;
+use PHPCensor\Plugin;
+
+/**
+ * Phlint is a tool with an aim to help maintain quality of php code by analyzing code and pointing out potential code
+ * issues. It focuses on how the code works rather than how the code looks. Phlint is designed from the start to do
+ * deep semantic analysis rather than doing only shallow or stylistic analysis.
+ * https://gitlab.com/phlint/phlint
+ */
+class Phlint extends Plugin
+{
+    /** @var int */
+    protected $allowedErrors = 0;
+
+    /**
+     * @param Builder $builder
+     * @param Build   $build
+     * @param array   $options
+     *
+     * @throws \Exception
+     */
+    public function __construct(Builder $builder, Build $build, array $options = [])
+    {
+        parent::__construct($builder, $build, $options);
+
+        $this->executable = $this->findBinary('phlint');
+
+        if (isset($options['allowed_errors']) && \is_int($options['allowed_errors'])) {
+            $this->allowedErrors = $options['allowed_errors'];
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function execute()
+    {
+        $this->builder->executeCommand(
+            'cd "%s" && %s analyze --no-interaction --no-ansi',
+            $this->builder->buildPath,
+            $this->executable
+        );
+
+        // Define that the plugin succeed
+        $success = true;
+
+        $errors = $this->processReport($this->builder->getLastOutput());
+
+        if (0 < \count($errors)) {
+            if (-1 !== $this->allowedErrors && \count($errors) > $this->allowedErrors) {
+                $success = false;
+            }
+
+            foreach ($errors as $error) {
+                $this->build->reportError(
+                    $this->builder,
+                    self::pluginName(),
+                    $error['message'],
+                    BuildError::SEVERITY_HIGH,
+                    $error['file'],
+                    $error['line_from']
+                );
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * @return string
+     */
+    public static function pluginName()
+    {
+        return 'phlint';
+    }
+
+    /**
+     * @param string $output
+     * @return array
+     */
+    protected function processReport($output)
+    {
+        \file_put_contents('/var/repos/output', $output);
+        $data = \explode(\chr(226), \preg_replace('#\\x1b[[][^A-Za-z\n]*[A-Za-z]#', '', \trim($output)));
+        \array_pop($data);
+        \array_shift($data);
+
+        $errors = [];
+
+        if (0 < \count($data)) {
+            foreach ($data as $error) {
+                $error   = explode(PHP_EOL, $error);
+                $header  = substr(trim(array_shift($error)), 3);
+                $file    = strstr(substr(strstr($header, 'in '), 3), ':', true);
+                $line    = substr(strrchr($header, ':'), 1);
+                $message = ltrim($error[0]);
+
+                $errors[] = [
+                    'message'      => $message,
+                    'file'         => $file,
+                    'line_from'    => $line
+                ];
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/Plugin/Phlint.php
+++ b/src/Plugin/Phlint.php
@@ -32,7 +32,7 @@ class Phlint extends Plugin
 
         $this->executable = $this->findBinary('phlint');
 
-        if (isset($options['allowed_errors']) && \is_int($options['allowed_errors'])) {
+        if (\array_key_exists($options, 'allowed_errors') && \is_int($options['allowed_errors'])) {
             $this->allowedErrors = $options['allowed_errors'];
         }
     }
@@ -99,7 +99,7 @@ class Phlint extends Plugin
                 $header  = \substr(\trim(\array_shift($error)), 3);
                 $file    = \strstr(\substr(\strstr($header, 'in '), 3), ':', true);
                 $line    = \substr(\strrchr($header, ':'), 1);
-                $message = \ltrim($error[0]);
+                $message = \ltrim($error[0]) . PHP_EOL . \ltrim($error[1]);
 
                 $errors[] = [
                     'message'      => $message,

--- a/src/Plugin/Phlint.php
+++ b/src/Plugin/Phlint.php
@@ -96,11 +96,11 @@ class Phlint extends Plugin
 
         if (0 < \count($data)) {
             foreach ($data as $error) {
-                $error   = explode(PHP_EOL, $error);
-                $header  = substr(trim(array_shift($error)), 3);
-                $file    = strstr(substr(strstr($header, 'in '), 3), ':', true);
-                $line    = substr(strrchr($header, ':'), 1);
-                $message = ltrim($error[0]);
+                $error   = \explode(PHP_EOL, $error);
+                $header  = \substr(\trim(\array_shift($error)), 3);
+                $file    = \strstr(\substr(\strstr($header, 'in '), 3), ':', true);
+                $line    = \substr(\strrchr($header, ':'), 1);
+                $message = \ltrim($error[0]);
 
                 $errors[] = [
                     'message'      => $message,

--- a/src/Plugin/Phlint.php
+++ b/src/Plugin/Phlint.php
@@ -87,7 +87,6 @@ class Phlint extends Plugin
      */
     protected function processReport($output)
     {
-        \file_put_contents('/var/repos/output', $output);
         $data = \explode(\chr(226), \preg_replace('#\\x1b[[][^A-Za-z\n]*[A-Za-z]#', '', \trim($output)));
         \array_pop($data);
         \array_shift($data);


### PR DESCRIPTION
Runs [Phlint](https://gitlab.com/phlint/phlint) against your build.

Phlint is a tool with an aim to help maintain quality of php code by analyzing code and pointing out potential code
issues. It focuses on how the code works rather than how the code looks. Phlint is designed from the start to do
deep semantic analysis rather than doing only shallow or stylistic analysis.

Requires PHP 5.5 and above.

```yml
test:
  phlint: ~
```
![image](https://user-images.githubusercontent.com/400362/52912368-46d1bd80-32b9-11e9-9296-2cadbd2ac1f6.png)
![image](https://user-images.githubusercontent.com/400362/52912370-4cc79e80-32b9-11e9-8b72-099bd1a38a6a.png)

```yml
test:
  phlint:
    allowed_errors: -1
```
![image](https://user-images.githubusercontent.com/400362/52912377-636df580-32b9-11e9-9bb9-c0c7a0ddd341.png)

My **phlint.configuration.distributed.php** file for the project was:
```php
<?php

return function ($phlint) {

  // Find code through Composer autoloader.
  $phlint[] = new \phlint\autoload\Composer(__dir__ . '/composer.json');

  // Where to look for code to analyze.
  $phlint->addPath(__dir__ . '/src/');
  $phlint->addPath(__dir__ . '/tests/');

  // Not all rules are enabled by default.
  $phlint->enableRule('all');

};
```