### PR TITLE
Bug fix for PHPUnit-Coverage reports in BitbucketNotify Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 
 services:
     - mysql
+    - postgresql
 
 install:
     - composer selfupdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ php:
 matrix:
     fast_finish: true
 
+services:
+    - mysql
+
 install:
     - composer selfupdate
     - composer install

--- a/src/Plugin/BitbucketNotify.php
+++ b/src/Plugin/BitbucketNotify.php
@@ -312,7 +312,7 @@ class BitbucketNotify extends Plugin
         );
         $currentBranchCoverage = json_decode($currentMetaData->getMetaValue(), true);
 
-        return new BitbucketNotifyPluginResult(
+        return new Plugin\Util\BitbucketNotifyPhpUnitResult(
             PhpUnit::pluginName() . '-coverage',
             isset($targetBranchCoverage['lines']) ? $targetBranchCoverage['lines'] : 0,
             isset($currentBranchCoverage['lines']) ? $currentBranchCoverage['lines'] : 0

--- a/src/Plugin/Util/BitbucketNotifyPhpUnitResult.php
+++ b/src/Plugin/Util/BitbucketNotifyPhpUnitResult.php
@@ -13,4 +13,9 @@ class BitbucketNotifyPhpUnitResult extends BitbucketNotifyPluginResult
     {
         return $this->right < $this->left;
     }
+
+    protected function getTaskDescriptionMessage()
+    {
+        return 'pls fix %s because the coverage has decreased from %d to %d';
+    }
 }

--- a/src/Plugin/Util/BitbucketNotifyPhpUnitResult.php
+++ b/src/Plugin/Util/BitbucketNotifyPhpUnitResult.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PHPCensor\Plugin\Util;
+
+class BitbucketNotifyPhpUnitResult extends BitbucketNotifyPluginResult
+{
+    public function isImproved()
+    {
+        return $this->right > $this->left;
+    }
+
+    public function isDegraded()
+    {
+        return $this->right < $this->left;
+    }
+}

--- a/src/Plugin/Util/BitbucketNotifyPluginResult.php
+++ b/src/Plugin/Util/BitbucketNotifyPluginResult.php
@@ -86,11 +86,16 @@ class BitbucketNotifyPluginResult
         }
 
         return sprintf(
-            'pls fix %s because it has increased from %d to %d errors',
+            $this->getTaskDescriptionMessage(),
             $this->plugin,
             $this->left,
             $this->right
         );
+    }
+
+    protected function getTaskDescriptionMessage()
+    {
+        return 'pls fix %s because it has increased from %d to %d errors';
     }
 
     public function __toString()

--- a/tests/src/Plugin/Util/BitbucketNotifyPhpUnitResultTest.php
+++ b/tests/src/Plugin/Util/BitbucketNotifyPhpUnitResultTest.php
@@ -4,7 +4,7 @@ namespace PHPCensor\Plugin\Util;
 
 use PHPUnit\Framework\TestCase;
 
-class BitbucketNotifyPluginResultTest extends TestCase
+class BitbucketNotifyPhpUnitResultTest extends TestCase
 {
     public function dataProvider()
     {
@@ -37,28 +37,28 @@ class BitbucketNotifyPluginResultTest extends TestCase
             ],
             'improved' => [
                 [
-                    'test', 1, 0,
+                    'test', 0, 1,
                 ],
                 [
                     'unchanged' => false,
                     'improved' => true,
                     'degraded' => false,
                     'string' => 'test',
-                    'formattedOutput' => "test       | 1\t=> 0\tgreat success!",
+                    'formattedOutput' => "test       | 0\t=> 1\tgreat success!",
                     'taskDescription' => '',
                 ]
             ],
             'degraded' => [
                 [
-                    'test', 0, 1,
+                    'test', 1, 0,
                 ],
                 [
                     'unchanged' => false,
                     'improved' => false,
                     'degraded' => true,
                     'string' => 'test',
-                    'formattedOutput' => "test       | 0\t=> 1\t!!!!! o_O",
-                    'taskDescription' => 'pls fix test because it has increased from 0 to 1 errors',
+                    'formattedOutput' => "test       | 1\t=> 0\t!!!!! o_O",
+                    'taskDescription' => 'pls fix test because the coverage has decreased from 1 to 0',
                 ]
             ],
         ];
@@ -69,44 +69,14 @@ class BitbucketNotifyPluginResultTest extends TestCase
      * @param array $input
      * @param array $expected
      */
-    public function test__toString(array $input, array $expected)
-    {
-        $sut = new BitbucketNotifyPluginResult($input[0], $input[1], $input[2]);
-        $this->assertEquals($expected['string'], $sut->__toString());
-    }
-
-    /**
-     * @dataProvider dataProvider
-     * @param array $input
-     * @param array $expected
-     */
     public function testFormating(array $input, array $expected)
     {
-        $pluginResult = new BitbucketNotifyPluginResult($input[0], $input[1], $input[2]);
+        $pluginResult = new BitbucketNotifyPhpUnitResult($input[0], $input[1], $input[2]);
         $this->assertEquals($expected['degraded'], $pluginResult->isDegraded());
         $this->assertSame($expected['taskDescription'], $pluginResult->generateTaskDescription());
         $this->assertSame($expected['formattedOutput'], $pluginResult->generateFormattedOutput(10));
         $this->assertEquals($expected['degraded'], $pluginResult->isDegraded());
         $this->assertEquals($expected['improved'], $pluginResult->isImproved());
         $this->assertEquals($expected['unchanged'], $pluginResult->isUnchanged());
-    }
-
-    public function testSetterGetter()
-    {
-        $pluginResult = new BitbucketNotifyPluginResult('noname', 9, 9);
-        $this->assertEquals(false, $pluginResult->isDegraded());
-        $this->assertEquals(false, $pluginResult->isImproved());
-        $this->assertEquals(true, $pluginResult->isUnchanged());
-
-        $pluginResult->setLeft(99);
-        $pluginResult->setRight(199);
-        $pluginResult->setPlugin('BestPluginEver4Cod1ng');
-
-        $this->assertEquals('99', $pluginResult->getLeft());
-        $this->assertEquals(199, $pluginResult->getRight());
-        $this->assertEquals('BestPluginEver4Cod1ng', $pluginResult->getPlugin());
-        $this->assertEquals(true, $pluginResult->isDegraded());
-        $this->assertEquals(false, $pluginResult->isImproved());
-        $this->assertEquals(false, $pluginResult->isUnchanged());
     }
 }


### PR DESCRIPTION
## Contribution type
Bug fix for PHPUnit-Coverage

## Description of change
- when using PHPUnit-Coverage statistics, higher coverage was treated as bad
- added special Class for BitbucketNotifyPhpUnitResult to see higher values as good and lower as bad