### PR TITLE
Delete Build Errors Log on Build Delete.

### DIFF
--- a/src/Model/Build.php
+++ b/src/Model/Build.php
@@ -126,6 +126,15 @@ class Build extends BaseBuild
     }
 
     /**
+     * Clean up Build Errors.
+     * @return bool
+     */
+    public function deleteBuildBuildErrors()
+    {
+        return Factory::getStore('BuildError')->deleteByBuildId($this->getId());
+    }
+
+    /**
      * Get BuildMeta models by BuildId for this Build.
      *
      * @return BuildMeta[]

--- a/src/Service/BuildService.php
+++ b/src/Service/BuildService.php
@@ -209,7 +209,7 @@ class BuildService
                         continue;
                     }
                 }
-                
+
                 $buildsCount++;
 
                 $this->createBuild(
@@ -281,10 +281,11 @@ class BuildService
     {
         $keepBuilds = (int)Config::getInstance()->get('php-censor.build.keep_builds', 100);
         $builds     = $this->buildStore->getOldByProject((int)$projectId, $keepBuilds);
-        
+
         /** @var Build $build */
         foreach ($builds['items'] as $build) {
             $build->removeBuildDirectory(true);
+            $build->deleteBuildBuildErrors();
             $this->buildStore->delete($build);
         }
     }
@@ -327,6 +328,7 @@ class BuildService
     public function deleteBuild(Build $build)
     {
         $build->removeBuildDirectory(true);
+        $build->deleteBuildBuildErrors();
 
         return $this->buildStore->delete($build);
     }

--- a/src/Store/BuildErrorStore.php
+++ b/src/Store/BuildErrorStore.php
@@ -323,4 +323,26 @@ class BuildErrorStore extends Store
         $stmt->execute();
         return $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
     }
+
+    /**
+     * Delete Errors for Build.
+     *
+     * @param  int $obj
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    public function deleteByBuildId(int $buildId)
+    {
+        $q = Database::getConnection('write')
+            ->prepareCommon(
+                sprintf(
+                    'DELETE FROM {{%s}} WHERE {{build_id}} = :build',
+                    $this->tableName
+                )
+            );
+        $q->bindValue(':build', $buildId);
+        $q->execute();
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Contribution type

Feature, tidy.

## Description of change

When a build is deleted, we don't clean up the `build_error` table. After a while this table gets pretty big and performance gets impacted, especially on big projects.
