### PR TITLE
Updated Copyright for PHP Censor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, PHP Censor
+Copyright (c) 2019, PHP Censor
 All rights reserved.
 
 Copyright (c) 2013, PHPCI, Block 8 Limited


### PR DESCRIPTION
From 2016 to 2019.

## Contribution type

Copyright update

## Description of change

Changed year from 2016 to 2019
