### PR TITLE
Fix deleting of old builds on MySQL

### DIFF
--- a/src/Store/BuildStore.php
+++ b/src/Store/BuildStore.php
@@ -523,7 +523,7 @@ class BuildStore extends Store
             throw new HttpException('Value passed to ' . __FUNCTION__ . ' cannot be null.');
         }
 
-        $query = 'SELECT * FROM {{' . $this->tableName . '}} WHERE {{project_id}} = :project_id ORDER BY {{create_date}} DESC OFFSET :keep';
+        $query = 'SELECT * FROM {{' . $this->tableName . '}} WHERE {{project_id}} = :project_id ORDER BY {{create_date}} DESC LIMIT 1000000 OFFSET :keep';
         $stmt = Database::getConnection('read')->prepareCommon($query);
         $stmt->bindValue(':project_id', $projectId);
         $stmt->bindValue(':keep', (int)$keep, \PDO::PARAM_INT);


### PR DESCRIPTION
Clicking on _Delete old builds_ fails with `Message: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OFFSET 100' at line 1`.

MySQL requires LIMIT to use OFFSET.

Use large number as limit to select all builds.

