### PR TITLE
Symfony security checker

### DIFF
--- a/docs/en/plugins/security_checker.md
+++ b/docs/en/plugins/security_checker.md
@@ -11,3 +11,11 @@ Configuration
 * **allowed_warnings** [int, optional] - Allow `n` warnings in a successful build (default: 0). 
   Use -1 to allow unlimited warnings.
 
+### Additional Options
+
+When you set **binary_name** (probably symfony), then instead of directly contacting the online security checker, this 
+binary is run like `symfony security:check`. The same security data is used, but it is downloaded and cached. 
+See [checking for vulnerabilites](https://github.com/FriendsOfPHP/security-advisories#checking-for-vulnerabilities)
+
+* **binary_name** [string|array, optional] - Allows you to provide a name of the binary.
+* **binary_path** [string, optional] - Allows you to provide a path to the binary vendor/bin, or a system-provided.

--- a/src/Plugin/SecurityChecker.php
+++ b/src/Plugin/SecurityChecker.php
@@ -7,6 +7,7 @@ use PHPCensor\Builder;
 use PHPCensor\Model\Build;
 use PHPCensor\Model\BuildError;
 use PHPCensor\Plugin;
+use PHPCensor\Plugin\Util\SymfonySecurityChecker;
 use PHPCensor\ZeroConfigPluginInterface;
 use SensioLabs\Security\SecurityChecker as BaseSecurityChecker;
 
@@ -64,8 +65,12 @@ class SecurityChecker extends Plugin implements ZeroConfigPluginInterface
 
     public function execute()
     {
+        if (!$this->binaryName) {
+            $checker = new BaseSecurityChecker();
+        } else {
+            $checker = new SymfonySecurityChecker($this);
+        }
         $success  = true;
-        $checker  = new BaseSecurityChecker();
         $result   = $checker->check($this->builder->buildPath . 'composer.lock');
         $warnings = json_decode((string)$result, true);
 

--- a/src/Plugin/SecurityChecker.php
+++ b/src/Plugin/SecurityChecker.php
@@ -92,7 +92,7 @@ class SecurityChecker extends Plugin implements ZeroConfigPluginInterface
                 $success = false;
             }
         } elseif (null === $warnings && $result) {
-            $this->builder->logWarning('invalid json: '.$result);
+            throw new \RuntimeException('invalid json: '.$result);
         }
 
         return $success;

--- a/src/Plugin/SecurityChecker.php
+++ b/src/Plugin/SecurityChecker.php
@@ -91,6 +91,8 @@ class SecurityChecker extends Plugin implements ZeroConfigPluginInterface
             if ($this->allowedWarnings != -1 && ($result->count() > $this->allowedWarnings)) {
                 $success = false;
             }
+        } elseif (null === $warnings && $result) {
+            $this->builder->logWarning('invalid json: '.$result);
         }
 
         return $success;

--- a/src/Plugin/Util/SymfonySecurityChecker.php
+++ b/src/Plugin/Util/SymfonySecurityChecker.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PHPCensor\Plugin\Util;
+
+use PHPCensor\Plugin;
+
+/**
+ * Check security with "symfony security:check"
+ *
+ * Class is compatible to SensionLabs\Security\SecurityChecker
+ */
+class SymfonySecurityChecker
+{
+    /**
+     * @var Plugin
+     */
+    private $plugin;
+
+    public function __construct(Plugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Checks a composer.lock file.
+     *
+     * @param string $lock The path to the composer.lock file
+     *
+     * @return string vulnerabilities as json
+     *
+     * @throws \RuntimeException When the lock file does not exist
+     */
+    public function check($lock)
+    {
+        if (!is_file($lock)) {
+            throw new \RuntimeException('Lock file does not exist.');
+        }
+
+        $cmd = '%s check:security --format=json --dir=%s';
+        $executable = $this->plugin->findBinary('symfony');
+        $builder = $this->plugin->getBuilder();
+        if (!$this->plugin->getBuild()->isDebug()) {
+            $builder->logExecOutput(false);
+        }
+
+        // works with dir, composer.lock, composer.json
+        $builder->executeCommand($cmd, $executable, $lock);
+
+        $builder->logExecOutput(true);
+        $output = $builder->getLastOutput();
+
+        return $output;
+    }
+}


### PR DESCRIPTION
## Contribution type

improvement

## Description of change

Security checker can be configured to use the binary `symfony` (as recommended by https://github.com/FriendsOfPHP/security-advisories#checking-for-vulnerabilities).