### PR TITLE
Worker stop

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -76,8 +76,8 @@ class WorkerCommand extends LoggingCommand
             );
         }
         if ($input->getOption('stop-worker')) {
-            $jobData = ['build_id' => BuildWorker::JOB_ID_STOP];
-            $this->buildService->addJobToQueue(BuildWorker::JOB_TYPE, $jobData, 0 /* priority high */);
+            $jobData = [];
+            $this->buildService->addJobToQueue(BuildWorker::JOB_STOP, $jobData, 0 /* priority high */);
 
             return;
         }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -42,7 +42,7 @@ class WorkerCommand extends LoggingCommand
 
     protected function configure()
     {
-        $whenHints = 'soon=when next job done, done=when current jobs done, idle=when waiting for jobs';
+        $whenHints = 'soon=when next job done (default), done=when current jobs done, idle=when waiting for jobs';
         $this
             ->setName('php-censor:worker')
             ->addOption(
@@ -56,7 +56,7 @@ class WorkerCommand extends LoggingCommand
                 '',
                 InputOption::VALUE_OPTIONAL,
                 "Gracefully stop one worker ($whenHints)",
-                'soon'
+                false // default value is used when option not given
             )
             ->setDescription('Runs the PHP Censor build worker.');
     }
@@ -77,9 +77,10 @@ class WorkerCommand extends LoggingCommand
                 'The worker is not configured. You must set a host and queue in your config.yml file.'
             );
         }
-        if ($value = $input->getOption('stop-worker')) {
+        $value = $input->getOption('stop-worker');
+        if (false !== $value) {
             $priority = Pheanstalk::DEFAULT_PRIORITY;
-            if ('soon' === $value) {
+            if ('soon' === $value || null === $value) {
                 $priority /= 2; // high priority, stop soon
             } elseif ('done' === $value) {
                 // default priority, stop when current queued done

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -50,6 +50,12 @@ class WorkerCommand extends LoggingCommand
                 InputOption::VALUE_NONE,
                 'Allow worker run periodical work'
             )
+            ->addOption(
+                'stop-worker',
+                '',
+                InputOption::VALUE_NONE,
+                'Gracefully stop one worker'
+            )
             ->setDescription('Runs the PHP Censor build worker.');
     }
 
@@ -68,6 +74,12 @@ class WorkerCommand extends LoggingCommand
             throw new RuntimeException(
                 'The worker is not configured. You must set a host and queue in your config.yml file.'
             );
+        }
+        if ($input->getOption('stop-worker')) {
+            $jobData = ['build_id' => BuildWorker::JOB_ID_STOP];
+            $this->buildService->addJobToQueue(BuildWorker::JOB_TYPE, $jobData, 0 /* priority high */);
+
+            return;
         }
 
         (new BuildWorker(

--- a/src/Worker/BuildWorker.php
+++ b/src/Worker/BuildWorker.php
@@ -18,7 +18,7 @@ use PHPCensor\Store\Factory;
 class BuildWorker
 {
     const JOB_TYPE = 'php-censor.build';
-    const JOB_ID_STOP = '.php-censor.worker.stop';
+    const JOB_STOP = 'php-censor.stop-flag';
 
     /**
      * If this variable changes to false, the worker will stop after the current build.
@@ -265,7 +265,11 @@ class BuildWorker
             ? $jobData['type']
             : '';
 
-        if (self::JOB_TYPE !== $jobType) {
+        if (self::JOB_STOP === $jobType) {
+            $this->stopWorker(); // stop worker on next loop
+
+            return false;
+        } elseif (self::JOB_TYPE !== $jobType) {
             $this->logger->warning(
                 sprintf(
                     'Invalid job (#%s) type "%s" in the queue tube "%s"!',
@@ -274,11 +278,6 @@ class BuildWorker
                     $this->queueTube
                 )
             );
-
-            return false;
-        }
-        if (self::JOB_ID_STOP === $jobData['build_id']) {
-            $this->stopWorker();
 
             return false;
         }

--- a/src/Worker/BuildWorker.php
+++ b/src/Worker/BuildWorker.php
@@ -18,6 +18,7 @@ use PHPCensor\Store\Factory;
 class BuildWorker
 {
     const JOB_TYPE = 'php-censor.build';
+    const JOB_ID_STOP = '.php-censor.worker.stop';
 
     /**
      * If this variable changes to false, the worker will stop after the current build.
@@ -273,6 +274,11 @@ class BuildWorker
                     $this->queueTube
                 )
             );
+
+            return false;
+        }
+        if (self::JOB_ID_STOP === $jobData['build_id']) {
+            $this->stopWorker();
 
             return false;
         }


### PR DESCRIPTION
## Contribution type

feature

## Description of change

Add an option to the worker command to stop a worker gracefully. With the 2nd commit, a cron job could start a worker and right thereafter execute `bin/console php-censor:worker --stop-worker=idle` to let more jobs run during night.
There is currently no possibility to influence what worker to stop. So it is not nicely possible to restart all workers after updateing phpcensor.