### PR TITLE
support job priority for projects

### DIFF
--- a/docs/en/configuring_project.md
+++ b/docs/en/configuring_project.md
@@ -73,6 +73,7 @@ build_settings:
   priority_path: binary_path
   binary_path:   /home/user/bin/
   directory:     /home/project
+  build_priority: 1 # only in web-interface
   ignore:
     - "vendor"
     - "tests"
@@ -169,6 +170,12 @@ plugin option `priority_path`).
 
 * Option `prefer_symlink` allows to use symlinks as a source build path. The option works only for local build source 
 (`LocalBuild`).
+
+* Option `build_priority: N` builds of a project with a higher value (like 4) are handled after builds of projects 
+with lower values (like -2). Default is 0.
+
+    **ATTENTION!:** Option `build_priority` should be set only from web-interface (Project edit page) because it only 
+    has an effect before the repository is cloned.
 
 * Also we have global options (Usually connection settings) for some plugins like: ([Campfire](plugins/campfire.md), 
 [Irc](plugins/irc.md), [Mysql](plugins/mysql.md), [Pgsql](plugins/pgsql.md) и [Sqlite](plugins/sqlite.md)). See 

--- a/src/Command/RebuildQueueCommand.php
+++ b/src/Command/RebuildQueueCommand.php
@@ -74,7 +74,7 @@ class RebuildQueueCommand extends Command
             $build = BuildFactory::getBuild($build);
 
             $this->logger->addInfo('Added build #' . $build->getId() . ' to queue.');
-            $buildService->addBuildToQueue($build);
+            $buildService->addBuildToQueue($build); // default priority because no project is here
         }
     }
 }

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -270,4 +270,21 @@ class Project extends BaseProject
 
         return $branches;
     }
+
+    /**
+     * @return int
+     */
+    public function getRelativeBuildPriority()
+    {
+        $config = $this->getBuildConfig();
+        if ($config) {
+            $yamlParser  = new YamlParser();
+            $parsed = $yamlParser->parse($config);
+            if (isset($parsed['build_settings']['build_priority'])) {
+                return (int)$parsed['build_settings']['build_priority'];
+            }
+        }
+
+        return 0;
+    }
 }

--- a/src/Service/BuildService.php
+++ b/src/Service/BuildService.php
@@ -266,7 +266,7 @@ class BuildService
         if (!empty($buildId)) {
             $build = BuildFactory::getBuild($build);
             $build->sendStatusPostback();
-            $this->addBuildToQueue($build);
+            $this->addBuildToQueue($build); // default priority because no project is initialized here
         }
 
         return $build;

--- a/src/Service/BuildService.php
+++ b/src/Service/BuildService.php
@@ -119,7 +119,7 @@ class BuildService
         if (!empty($buildId)) {
             $build = BuildFactory::getBuild($build);
             $build->sendStatusPostback();
-            $this->addBuildToQueue($build);
+            $this->addBuildToQueue($build, $project->getRelativeBuildPriority());
         }
 
         return $build;
@@ -334,8 +334,9 @@ class BuildService
     /**
      * Takes a build and puts it into the queue to be run (if using a queue)
      * @param Build $build
+     * @param int   $relPriority priority in queue relative to default
      */
-    public function addBuildToQueue(Build $build)
+    public function addBuildToQueue(Build $build, $relPriority = 0)
     {
         $buildId = $build->getId();
 


### PR DESCRIPTION
## Contribution type

feature

## Description of change

With the project setting 'build_priority', the project builds can get higher or lower priority, which influences the execution order of waiting builds.
