### PR TITLE
early hint in doc that clone_depth is only supported in web-interface 

### DIFF
--- a/docs/en/configuring_project.md
+++ b/docs/en/configuring_project.md
@@ -69,7 +69,7 @@ Config example:
 
 ```yml
 build_settings:
-  clone_depth: 1
+  clone_depth: 1 # only in web-interface
   priority_path: binary_path
   binary_path:   /home/user/bin/
   directory:     /home/project


### PR DESCRIPTION
## Contribution type

doc enhancement

## Description of change

Add additional hint that clone_depth is only supported in web-interface.