### PR TITLE
Fixed SQLite plugin PDO initialization. Issue #377.

### DIFF
--- a/src/Plugin/Sqlite.php
+++ b/src/Plugin/Sqlite.php
@@ -89,7 +89,7 @@ class Sqlite extends Plugin
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
             ], $this->pdoOptions);
 
-            $pdo  = new PDO('sqlite:' . $this->path, $pdoOptions);
+            $pdo  = new PDO(('sqlite:' . $this->path), null, null, $pdoOptions);
 
             foreach ($this->queries as $query) {
                 $pdo->query($query);


### PR DESCRIPTION
## Contribution type

Bugfix.

## Description of change

Fixed #377 (SQLite PDO class constructor evoke with wrong params order).
