### PR TITLE
Fix PHP 8.0 deprecations

### DIFF
--- a/src/Plugin/Util/Factory.php
+++ b/src/Plugin/Util/Factory.php
@@ -180,10 +180,13 @@ class Factory
      */
     private function getParamType(ReflectionParameter $param)
     {
-        $class = $param->getClass();
+        $class = $param->getType() && !$param->getType()->isBuiltin()
+            ? new ReflectionClass($param->getType()->getName())
+            : null;
+
         if ($class) {
             return $class->getName();
-        } elseif ($param->isArray()) {
+        } elseif ($param->getType() && $param->getType()->getName() === 'array') {
             return self::TYPE_ARRAY;
         } elseif (is_callable($param)) {
             return self::TYPE_CALLABLE;


### PR DESCRIPTION
## Contribution type

*Deprecation fix*

## Description of change

PHP 8 throws the follwing errors:
```
Exception: Deprecated: Method ReflectionParameter::getClass() is deprecated in <PHP_CENSOR_PATH>/src/Plugin/Util/Factory.php line 183
or
Exception: Deprecated: Method ReflectionParameter::isArray() is deprecated in <PHP_CENSOR_PATH>/src/Plugin/Util/Factory.php line 188
```
<br>

Credits: https://php.watch/versions/8.0/deprecated-reflectionparameter-methods