### PR TITLE
Use Plugin::findBinary instead Builder::findBinary

### DIFF
--- a/src/Plugin/Mage.php
+++ b/src/Plugin/Mage.php
@@ -35,7 +35,7 @@ class Mage extends Plugin
     {
         parent::__construct($builder, $build, $options);
 
-        $this->executable = $this->builder->findBinary(['mage', 'mage.phar']);
+        $this->executable = $this->findBinary(['mage', 'mage.phar']);
 
         if (isset($options['env'])) {
             $this->mageEnv = $builder->interpolate($options['env']);

--- a/src/Plugin/Mage3.php
+++ b/src/Plugin/Mage3.php
@@ -36,7 +36,7 @@ class Mage3 extends Plugin
     {
         parent::__construct($builder, $build, $options);
 
-        $this->executable = $this->builder->findBinary(['mage', 'mage.phar']);
+        $this->executable = $this->findBinary(['mage', 'mage.phar']);
 
         if (isset($options['env'])) {
             $this->mageEnv = $builder->interpolate($options['env']);


### PR DESCRIPTION
## Contribution type

*Bug fix*

## Description of change

When you try to deploy with custom settings like "binary_path", "priority_path" for Plugin Mage/Mage3, the settings are not used.
