### PR TITLE
Fix: Incorrect directories provided for PHPStan analyse

### DIFF
--- a/docs/en/plugins/php_stan.md
+++ b/docs/en/plugins/php_stan.md
@@ -12,6 +12,7 @@ Configuration
 
 ### Options
 
+* **directories** [array, optional] - An array of paths in which you wish to run PHPStan on. This overrides  `directory`.
 * **allowed_errors** [int, optional] - Allow `n` errors in a successful build (default: 0). 
   Use -1 to allow unlimited warnings.
   
@@ -19,7 +20,10 @@ Configuration
 
 ```yaml
 test:
-  php_stan: ~
+  php_stan:
+    directories:
+      - src
+      - tests
 ```
 
 ### Additional Options
@@ -27,7 +31,7 @@ test:
 The following general options can also be used: 
 
 * **allow_failures** [bool, optional] - If true, allow the build to succeed even if this plugin fails.
-* **directory** [string, optional] - This option lets you specify the tests directory to run.
+* **directory** [string, optional] - Deprecated: This option lets you specify the list of space-separated directories to run.
 * **ignore** [optional] - A list of files / paths to ignore (default: build_settings > ignore).
 * **binary_name** [string|array, optional] - Allows you to provide a name of the binary.
 * **binary_path** [string, optional] - Allows you to provide a path to the binary vendor/bin, or a system-provided.

--- a/src/Plugin/PhpStan.php
+++ b/src/Plugin/PhpStan.php
@@ -17,6 +17,8 @@ use PHPCensor\Plugin;
  */
 class PhpStan extends Plugin
 {
+    /** @var string[] */
+    protected $directories = [];
     /** @var int */
     protected $allowedErrors = 0;
 
@@ -32,6 +34,17 @@ class PhpStan extends Plugin
         parent::__construct($builder, $build, $options);
 
         $this->executable = $this->findBinary(['phpstan', 'phpstan.phar']);
+
+        if (!empty($options['directories']) && is_array($options['directories'])) {
+            $this->directories = $options['directories'];
+        } elseif (!empty($options['directory']) && is_string($options['directory'])) {
+            /** @deprecated Option "directory" is deprecated. Use the option "directories" instead. */
+            $this->directories = explode(' ', $options['directory']);
+
+            $this->builder->logWarning(
+                '[DEPRECATED] Option "directory" is deprecated. Use the option "directories" instead.'
+            );
+        }
 
         if (isset($options['allowed_errors']) && is_int($options['allowed_errors'])) {
             $this->allowedErrors = $options['allowed_errors'];
@@ -50,9 +63,9 @@ class PhpStan extends Plugin
         }
 
         $this->builder->executeCommand(
-            'cd "%s" && ' . $phpStan . ' analyze --error-format=json "%s"',
+            'cd "%s" && ' . $phpStan . ' analyze --error-format=json %s',
             $this->builder->buildPath,
-            $this->directory
+            implode(' ', $this->directories)
         );
         $this->builder->logExecOutput(true);
 


### PR DESCRIPTION
## Contribution type

Bug fix

## Description of change

PHPStan should analyze only subdirectories instead of the main `<BUILD_PATH>`.

Fixes https://github.com/php-censor/php-censor/issues/408