### PR TITLE
Added text on how to check if Beanstalkd is running, and how to start it

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Or download [latest archive](https://github.com/php-censor/php-censor/releases/l
 ```bash
 # For Debian-based
 aptitude install beanstalkd
+# Check if the service is running:
+/etc/init.d/beanstalkd status
+# If it's not running, start it:
+/etc/init.d/beanstalkd start
 ```
 
 * Install PHP Censor itself:


### PR DESCRIPTION
## Contribution type
Feature

## Description of change
Added 4 lines of text to manual on how to check if Beanstalkd is running, and how to start it.

See also https://github.com/php-censor/php-censor/issues/410