### PR TITLE
Support plugin option in config

### DIFF
--- a/public/assets/js/build-plugins/summary.js
+++ b/public/assets/js/build-plugins/summary.js
@@ -35,6 +35,7 @@ var SummaryPlugin = ActiveBuild.UiPlugin.extend({
             '<table class="table table-hover" id="plugin-summary">' +
             '<thead><tr>' +
             '<th>' + Lang.get('stage') + '</th>' +
+            '<th>' + Lang.get('step') + '</th>' +
             '<th>' + Lang.get('plugin') + '</th>' +
             '<th>' + Lang.get('status') + '</th>' +
             '<th class="text-right">' + Lang.get('duration') + ' (' + Lang.get('seconds') + ')</th>' +
@@ -54,9 +55,10 @@ var SummaryPlugin = ActiveBuild.UiPlugin.extend({
         tbody.empty();
 
         for (var stage in summary) {
-            for (var plugin in summary[stage]) {
-                var data     = summary[stage][plugin],
-                    duration = data.started ? ((data.ended || Math.floor(Date.now() / 1000)) - data.started) : '-';
+            for (var step in summary[stage]) {
+                var data     = summary[stage][step],
+                    duration = data.started ? ((data.ended || Math.floor(Date.now() / 1000)) - data.started) : '-',
+                    plugin = (typeof data.plugin === "undefined" ? step : data.plugin);
 
                 var pluginName = Lang.get(plugin);
                 if (0 < data.errors) {
@@ -65,6 +67,7 @@ var SummaryPlugin = ActiveBuild.UiPlugin.extend({
                 tbody.append(
                     '<tr>' +
                     '<td>' + Lang.get('stage_' + stage) + '</td>' +
+                    '<td>' + step + '</td>' +
                     '<td>' + pluginName + '</td>' +
                     '<td><span  class="label label-' + this.statusClasses[data.status] + '">' +
                     this.statusLabels[data.status] +

--- a/src/Languages/lang.en.php
+++ b/src/Languages/lang.en.php
@@ -347,6 +347,7 @@ PHP Censor',
     // Summary plugin
     'build-summary'  => 'Summary',
     'stage'          => 'Stage',
+    'step'           => 'Step',
     'duration'       => 'Duration',
     'seconds'        => 'sec.',
     'plugin'         => 'Plugin',


### PR DESCRIPTION
## Contribution type

feature

## Description of change

Add support for allowing the same plugin to be run multiple times as well as naming steps, Great for providing seperate run times for each step. This has been done by adding an option to the config called 'plugin'.

Example
`
setup:
  setup_env:
    plugin: shell
    commands:
      - "php -r \"copy('.env.ci', '.env');\""
      - "php artisan key:generate"
      - "chmod -R 777 storage bootstrap/cache"
  migrate:
    plugin: shell
    commands:
      - "php artisan migrate"
  seed:
    plugin: shell
    commands:
      - "php artisan db:seed"
`

![image](https://user-images.githubusercontent.com/679994/128356358-d6b7dede-6f73-4e94-9dc8-e8f2f60f9d40.png)
![image](https://user-images.githubusercontent.com/679994/128356437-817e5639-f68d-4cb7-a94a-fd069e320761.png)
