### PR TITLE
Disable maintainAspectRatio

### DIFF
--- a/public/assets/js/build-plugins/loc.js
+++ b/public/assets/js/build-plugins/loc.js
@@ -104,7 +104,8 @@ var locPlugin = ActiveBuild.UiPlugin.extend({
                 data: self.chartData,
                 options: {
                     datasetFill:          false,
-                    multiTooltipTemplate: "<%=datasetLabel%>: <%= value %>"
+                    multiTooltipTemplate: "<%=datasetLabel%>: <%= value %>",
+                    maintainAspectRatio:  false
                 }
             });
 

--- a/public/assets/js/build-plugins/phpunit-coverage.js
+++ b/public/assets/js/build-plugins/phpunit-coverage.js
@@ -101,7 +101,8 @@ var coveragePlugin = ActiveBuild.UiPlugin.extend({
                     scaleStepWidth :      10,
                     scaleStartValue :     0,
                     datasetFill:          false,
-                    multiTooltipTemplate: "<%=datasetLabel%>: <%= value %>"
+                    multiTooltipTemplate: "<%=datasetLabel%>: <%= value %>",
+                    maintainAspectRatio:  false
                 }
             });
 

--- a/public/assets/js/build-plugins/warnings.js
+++ b/public/assets/js/build-plugins/warnings.js
@@ -160,7 +160,8 @@ var warningsPlugin = ActiveBuild.UiPlugin.extend({
                 data: self.chartData,
                 options: {
                     datasetFill: false,
-                    multiTooltipTemplate: "<%=datasetLabel%>: <%= value %>"
+                    multiTooltipTemplate: "<%=datasetLabel%>: <%= value %>",
+                    maintainAspectRatio: false
                 }
             });
 


### PR DESCRIPTION
## Contribution type

Bug fix

## Description of change

The graphs on the build view page can sometimes become malformed and ignore the parent height, disabling maintainAspectRatio fixed this issue.

Before:
![image](https://user-images.githubusercontent.com/679994/154243099-d0b44b00-861b-418e-9de9-12fb2ec7f3d4.png)

After:
![image](https://user-images.githubusercontent.com/679994/154243135-ad357326-740d-4347-8edf-3f4f3e35dd5b.png)
