### PR TITLE
Fix xdebug settings

### DIFF
--- a/src/Plugin/PhpLoc.php
+++ b/src/Plugin/PhpLoc.php
@@ -66,7 +66,7 @@ class PhpLoc extends Plugin implements ZeroConfigPluginInterface
 
         $phploc = $this->executable;
 
-        $success = $this->builder->executeCommand('cd "%s" && php -d xdebug.mode=0 -d error_reporting=0 ' . $phploc . ' %s %s', $this->builder->buildPath, $ignore, $this->directory);
+        $success = $this->builder->executeCommand('cd "%s" && php -d xdebug.mode=off -d error_reporting=0 ' . $phploc . ' %s %s', $this->builder->buildPath, $ignore, $this->directory);
         $output  = $this->builder->getLastOutput();
 
         if (\preg_match_all('/\((LOC|CLOC|NCLOC|LLOC)\)\s+([0-9]+)/', $output, $matches)) {

--- a/src/Plugin/PhpUnit.php
+++ b/src/Plugin/PhpUnit.php
@@ -191,6 +191,11 @@ class PhpUnit extends Plugin implements ZeroConfigPluginInterface
 
         $arguments = $this->builder->interpolate($options->buildArgumentString());
         $cmd       = $this->executable . ' %s %s';
+
+        if ($options->getOption('coverage')) {
+            $cmd = 'XDEBUG_MODE=coverage ' . $cmd;
+        }
+
         $success   = $this->executePhpUnitCommand($cmd, $arguments, $directory);
         $output    = $this->builder->getLastOutput();
         $covHtmlOk = false;


### PR DESCRIPTION
## Contribution type

Bug fix

## Description of change

PHPUnit code coverage was not being generated due to changes in xdebug v3, this will turn on coverage mode if the settings require it.
