### PR TITLE
PHP 8.1 deprecation while searching for composer binary

### DIFF
--- a/src/Helper/CommandExecutor.php
+++ b/src/Helper/CommandExecutor.php
@@ -295,7 +295,7 @@ class CommandExecutor implements CommandExecutorInterface
                     return $existedBinary;
                 }
 
-                if ($existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
+                if (null !== $composerBin && $existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
                     return $existedBinary;
                 }
 
@@ -311,7 +311,7 @@ class CommandExecutor implements CommandExecutorInterface
                     return $existedBinary;
                 }
 
-                if ($existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
+                if (null !== $composerBin && $existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
                     return $existedBinary;
                 }
 
@@ -327,7 +327,7 @@ class CommandExecutor implements CommandExecutorInterface
                     return $existedBinary;
                 }
 
-                if ($existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
+                if (null !== $composerBin && $existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
                     return $existedBinary;
                 }
 
@@ -339,7 +339,7 @@ class CommandExecutor implements CommandExecutorInterface
                     return $existedBinary;
                 }
             } else {
-                if ($existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
+                if (null !== $composerBin && $existedBinary = $this->findBinaryLocal($composerBin, $bin)) {
                     return $existedBinary;
                 }
 


### PR DESCRIPTION
## Contribution type

Bug fix

## Description of change

> Exception: Deprecated: is_dir(): Passing null to parameter #1 ($filename) of type string is deprecated in <PHP_CENSOR_PATH>/src/Helper/CommandExecutor.php line 238


This is because `CommandExecutor::getComposerBinDir` may return null.