### PR TITLE
Improve installation error message with uninstall instructions

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -156,8 +156,17 @@ class InstallCommand extends Command
 
             if (!empty($content)) {
                 $output->writeln(
-                    '<error>The PHP Censor config file exists and is not empty. ' .
+                    '<error>The PHP Censor config file already exists and is not empty. ' .
                     'PHP Censor is already installed!</error>'
+                );
+                $output->writeln(
+                    '<comment>If you want to reinstall, delete the config file by running:</comment>'
+                );
+                $output->writeln(
+                    '<comment>rm ' . $this->configPath . '</comment>'
+                );
+                $output->writeln(
+                    '<comment>Then, rerun the installation command.</comment>'
                 );
 
                 return false;


### PR DESCRIPTION
This PR improves the installation error message by providing instructions on how to reinstall PHP-Censor.

- The previous message only informed users that PHP-Censor was already installed.
- Now, it also suggests deleting the config file and rerunning the install command.

This makes it clearer for users who want to reinstall.

Let me know if any modifications are needed. Thanks!
