### PR TITLE
Telegram notify to group topic

### DIFF
--- a/docs/en/plugins/telegram_notify.md
+++ b/docs/en/plugins/telegram_notify.md
@@ -24,6 +24,7 @@ complete:
         recipients:
             - "<user id>"
             - "-<group id>"
+            - "-<group id>/<thread id>"
             - "@<channel id>"
         send_log: true
 ```

--- a/src/Plugin/TelegramNotify.php
+++ b/src/Plugin/TelegramNotify.php
@@ -90,6 +90,12 @@ class TelegramNotify extends Plugin
                 'text'       => $message,
                 'parse_mode' => 'Markdown',
             ];
+
+            $messageThreadId = $this->getMessageThreadIdFromGroupId($chatId);
+            if ($messageThreadId !== null) {
+                $params['message_thread_id'] = $messageThreadId;
+            }
+
             $client->post(('https://api.telegram.org' . $url), [
                 'headers' => [
                     'Content-Type' => 'application/json',
@@ -103,6 +109,11 @@ class TelegramNotify extends Plugin
                     'text'       => $this->buildMsg,
                     'parse_mode' => 'Markdown',
                 ];
+
+                if ($messageThreadId !== null) {
+                    $params['message_thread_id'] = $messageThreadId;
+                }
+
                 $client->post(('https://api.telegram.org' . $url), [
                     'headers' => [
                         'Content-Type' => 'application/json',
@@ -141,5 +152,17 @@ class TelegramNotify extends Plugin
         }
 
         return $this->builder->interpolate(\str_replace(['%ICON_BUILD%'], [$buildIcon], $this->message));
+    }
+
+    /**
+     * Split chat group id to chat id and message thread id
+     *
+     * @param string|int $chatId
+     * @return string|null
+     */
+    protected function getMessageThreadIdFromGroupId($chatId)
+    {
+        $parts = explode('/', $chatId);
+        return (count($parts) > 1 && $parts[1] !== '') ? $parts[1] : null;
     }
 }

--- a/tests/src/Plugin/TelegramNotifyTest.php
+++ b/tests/src/Plugin/TelegramNotifyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPCensor\Plugin;
+
+use PHPCensor\Plugin\TelegramNotify;
+use PHPUnit\Framework\TestCase;
+
+class TelegramNotifyTest extends TestCase
+{
+    /**
+     * @dataProvider chatIdProvider
+     */
+    public function testGetMessageThreadIdFromGroupId($chatId, $expectedThreadId): void
+    {
+        $reflection = new \ReflectionClass(TelegramNotify::class);
+        $method = $reflection->getMethod('getMessageThreadIdFromGroupId');
+        $method->setAccessible(true);
+        $instance = $reflection->newInstanceWithoutConstructor();
+
+        $result = $method->invoke($instance, $chatId);
+        self::assertSame($expectedThreadId, $result);
+    }
+
+    public function chatIdProvider(): array
+    {
+        return [
+            'without message thread id' => ['-12345', null],
+            'with message thread id' => ['12345/67890', '67890'],
+            'empty thread id' => ['12345/', null],
+            'not group chat' => ['12345', null],
+            'empty input' => ['', null],
+            'only slash' => ['/', null],
+            'double slash' => ['//', null],
+            'group id digits only' => [12345, null],
+        ];
+    }
+}

--- a/tests/src/Plugin/TelegramNotifyTest.php
+++ b/tests/src/Plugin/TelegramNotifyTest.php
@@ -12,10 +12,10 @@ class TelegramNotifyTest extends TestCase
     /**
      * @dataProvider chatIdProvider
      */
-    public function testGetMessageThreadIdFromGroupId($chatId, $expectedThreadId): void
+    public function testSplitChatIdAndTopicId($chatId, $expectedThreadId): void
     {
         $reflection = new \ReflectionClass(TelegramNotify::class);
-        $method = $reflection->getMethod('getMessageThreadIdFromGroupId');
+        $method = $reflection->getMethod('splitChatIdAndTopicId');
         $method->setAccessible(true);
         $instance = $reflection->newInstanceWithoutConstructor();
 
@@ -26,14 +26,17 @@ class TelegramNotifyTest extends TestCase
     public function chatIdProvider(): array
     {
         return [
-            'without message thread id' => ['-12345', null],
-            'with message thread id' => ['12345/67890', '67890'],
-            'empty thread id' => ['12345/', null],
-            'not group chat' => ['12345', null],
-            'empty input' => ['', null],
-            'only slash' => ['/', null],
-            'double slash' => ['//', null],
-            'group id digits only' => [12345, null],
+            'without message thread id' => ['-12345', ['-12345', null]],
+            'with message thread id' => ['12345/67890', ['12345', '67890']],
+            'empty thread id' => ['12345/', ['12345', null]],
+            'not group chat' => ['12345', ['12345', null]],
+            'empty input' => ['', ['', null]],
+            'only slash' => ['/', ['', null]],
+            'double slash' => ['//', ['', null]],
+            'group id digits only' => [12345, ['12345', null]],
+            'group id digits only (negative)' => [-12345, ['-12345', null]],
+            'zero topic id' => ['-12345/0', ['-12345', '0']],
+            'spaces' => ['   -12345/0   ', ['-12345', '0']],
         ];
     }
 }


### PR DESCRIPTION
## Contribution type

*Improvment TelegramNotify plugin*

## Description of change

These improvements allow to send notifications to individual topics within the telegram group.  The topic ID is separated by a slash after the group ID `-<group id>/<topic id>` in config. You can find out the topic ID using this guide.  https://gist.github.com/nafiesl/4ad622f344cd1dc3bb1ecbe468ff9f8a#get-chat-id-for-a-topic-in-a-group-chat