### PR TITLE
fix: prevent OS command injection via webhook branch parameter

### DIFF
--- a/src/Model/Build/GitBuild.php
+++ b/src/Model/Build/GitBuild.php
@@ -167,7 +167,7 @@ class GitBuild extends TypedBuild
 
         if (empty($this->getEnvironmentId()) && !empty($commitId)) {
             $cmd     = $chdir . ' && git checkout %s --quiet';
-            $success = $builder->executeCommand($cmd, $cloneTo, $commitId);
+            $success = $builder->executeCommand($cmd, $cloneTo, \escapeshellarg($commitId));
         }
 
         // Always update the commit hash with the actual HEAD hash
@@ -176,11 +176,11 @@ class GitBuild extends TypedBuild
 
             $this->setCommitId($commitId);
 
-            if ($builder->executeCommand($chdir . ' && git log -1 --pretty=format:%%s %s', $cloneTo, $commitId)) {
+            if ($builder->executeCommand($chdir . ' && git log -1 --pretty=format:%%s %s', $cloneTo, \escapeshellarg($commitId))) {
                 $this->setCommitMessage(\trim($builder->getLastOutput()));
             }
 
-            if ($builder->executeCommand($chdir . ' && git log -1 --pretty=format:%%ae %s', $cloneTo, $commitId)) {
+            if ($builder->executeCommand($chdir . ' && git log -1 --pretty=format:%%ae %s', $cloneTo, \escapeshellarg($commitId))) {
                 $this->setCommitterEmail(\trim($builder->getLastOutput()));
             }
         }

--- a/src/Model/Build/GitBuild.php
+++ b/src/Model/Build/GitBuild.php
@@ -102,8 +102,8 @@ class GitBuild extends TypedBuild
             $cmd .= ' --depth ' . \intval($buildSettings['clone_depth']) . ' ';
         }
 
-        $cmd .= ' -b "%s" "%s" "%s"';
-        $success = $builder->executeCommand($cmd, $this->getBranch(), $this->getCloneUrl(), $cloneTo);
+        $cmd .= ' -b %s "%s" "%s"';
+        $success = $builder->executeCommand($cmd, \escapeshellarg($this->getBranch()), $this->getCloneUrl(), $cloneTo);
 
         if ($success) {
             $success = $this->postCloneSetup($builder, $cloneTo);
@@ -132,10 +132,10 @@ class GitBuild extends TypedBuild
             $cmd .= ' --depth ' . \intval($buildSettings['clone_depth']) . ' ';
         }
 
-        $cmd .= ' -b "%s" "%s" "%s"';
+        $cmd .= ' -b %s "%s" "%s"';
         $cmd = 'export GIT_SSH="' . $gitSshWrapper . '" && ' . $cmd;
 
-        $success = $builder->executeCommand($cmd, $this->getBranch(), $this->getCloneUrl(), $cloneTo);
+        $success = $builder->executeCommand($cmd, \escapeshellarg($this->getBranch()), $this->getCloneUrl(), $cloneTo);
 
         if ($success) {
             $extra = [

--- a/src/Model/Build/HgBuild.php
+++ b/src/Model/Build/HgBuild.php
@@ -78,7 +78,7 @@ class HgBuild extends Build
      */
     protected function cloneByHttp(Builder $builder, $cloneTo)
     {
-        return $builder->executeCommand('hg clone %s "%s" -r %s', $this->getCloneUrl(), $cloneTo, $this->getBranch());
+        return $builder->executeCommand('hg clone %s "%s" -r %s', $this->getCloneUrl(), $cloneTo, \escapeshellarg($this->getBranch()));
     }
 
     /**
@@ -94,7 +94,7 @@ class HgBuild extends Build
 
         // Do the hg clone:
         $cmd     = 'hg clone --ssh "ssh -i ' . $keyFile . '" %s "%s" -r %s';
-        $success = $builder->executeCommand($cmd, $this->getCloneUrl(), $cloneTo, $this->getBranch());
+        $success = $builder->executeCommand($cmd, $this->getCloneUrl(), $cloneTo, \escapeshellarg($this->getBranch()));
 
         if ($success) {
             $success = $this->postCloneSetup($builder, $cloneTo);
@@ -121,7 +121,7 @@ class HgBuild extends Build
         // Allow switching to a specific branch:
         if (!empty($commitId)) {
             $cmd     = 'cd "%s" && hg checkout %s';
-            $success = $builder->executeCommand($cmd, $cloneTo, $this->getBranch());
+            $success = $builder->executeCommand($cmd, $cloneTo, \escapeshellarg($this->getBranch()));
         }
 
         return $success;


### PR DESCRIPTION
## Description

The `branch` parameter received from webhook requests is interpolated unsanitized into shell commands executed by `Process::fromShellCommandline()`. Since the webhook controller is whitelisted from authentication checks in `Application.php`, this allows **unauthenticated OS command injection** (CWE-78) — a remote attacker can achieve full Remote Code Execution by sending a crafted request to `/webhook/git/<projectId>?branch=$(arbitrary_command)`.

This patch applies `\escapeshellarg()` to the `branch` parameter at all injection points in `GitBuild` and `HgBuild`. For `GitBuild`, the double-quote wrapper `"%s"` around the branch placeholder is also removed so that the single quotes produced by `escapeshellarg()` are directly interpreted by the shell, effectively neutralizing `$()`, backticks, and other shell metacharacters.

## Affected Code

- `src/Model/Build/GitBuild.php` — `cloneByHttp()` (line 105-106), `cloneBySsh()` (line 135-138)
- `src/Model/Build/HgBuild.php` — `cloneByHttp()` (line 81), `cloneBySsh()` (line 96-97), `postCloneSetup()` (line 124)

## Changes

| File | Lines Changed | Detail |
|---|---|---|
| `src/Model/Build/GitBuild.php` | 4 | Wrap `$this->getBranch()` with `\escapeshellarg()` in `cloneByHttp()` and `cloneBySsh()`; change format string from `"%s"` to `%s` for branch position |
| `src/Model/Build/HgBuild.php` | 3 | Wrap `$this->getBranch()` with `\escapeshellarg()` in `cloneByHttp()`, `cloneBySsh()`, and `postCloneSetup()` |