### PR TITLE
fix: escape svn webhook commit id in export command

### DIFF
--- a/src/Model/Build/SvnBuild.php
+++ b/src/Model/Build/SvnBuild.php
@@ -111,7 +111,7 @@ class SvnBuild extends TypedBuild
 
         if (!empty($this->getCommitId())) {
             $cmd .= ' -r %s %s "%s"';
-            $success = $builder->executeCommand($cmd, $this->getCommitId(), $this->getCloneUrl(), $cloneTo);
+            $success = $builder->executeCommand($cmd, \escapeshellarg($this->getCommitId()), $this->getCloneUrl(), $cloneTo);
         } else {
             $cmd .= ' %s "%s"';
             $success = $builder->executeCommand($cmd, $this->getCloneUrl(), $cloneTo);


### PR DESCRIPTION
## Summary

This is a follow-up to #441 for the SVN build path.

`SvnBuild::cloneByHttp()` passes `getCommitId()` into the `svn export -r %s ...` shell command without escaping. The Git and Hg build paths now escape webhook-controlled command arguments, but the SVN path still missed the same treatment.

This PR applies `escapeshellarg()` to the SVN commit id before it is passed to `executeCommand()`.

## Testing

- `php -l src/Model/Build/SvnBuild.php`

Note: PHP 8.4 reports an existing deprecation warning for `${var}` string interpolation on line 59, but syntax validation succeeds.